### PR TITLE
Discuss binding immediates to instructions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-tools"
 authors = ["The Cranelift Project Developers"]
-version = "0.41.0"
+version = "0.42.0"
 description = "Binaries for testing the Cranelift libraries"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://cranelift.readthedocs.io/"
@@ -19,19 +19,19 @@ path = "src/clif-util.rs"
 
 [dependencies]
 cfg-if = "0.1"
-cranelift-codegen = { path = "cranelift-codegen", version = "0.41.0" }
-cranelift-entity = { path = "cranelift-entity", version = "0.41.0" }
-cranelift-reader = { path = "cranelift-reader", version = "0.41.0" }
-cranelift-frontend = { path = "cranelift-frontend", version = "0.41.0" }
-cranelift-serde = { path = "cranelift-serde", version = "0.41.0", optional = true }
-cranelift-wasm = { path = "cranelift-wasm", version = "0.41.0", optional = true }
-cranelift-native = { path = "cranelift-native", version = "0.41.0" }
-cranelift-filetests = { path = "cranelift-filetests", version = "0.41.0" }
-cranelift-module = { path = "cranelift-module", version = "0.41.0" }
-cranelift-faerie = { path = "cranelift-faerie", version = "0.41.0" }
-cranelift-simplejit = { path = "cranelift-simplejit", version = "0.41.0" }
-cranelift-preopt = { path = "cranelift-preopt", version = "0.41.0" }
-cranelift = { path = "cranelift-umbrella", version = "0.41.0" }
+cranelift-codegen = { path = "cranelift-codegen", version = "0.42.0" }
+cranelift-entity = { path = "cranelift-entity", version = "0.42.0" }
+cranelift-reader = { path = "cranelift-reader", version = "0.42.0" }
+cranelift-frontend = { path = "cranelift-frontend", version = "0.42.0" }
+cranelift-serde = { path = "cranelift-serde", version = "0.42.0", optional = true }
+cranelift-wasm = { path = "cranelift-wasm", version = "0.42.0", optional = true }
+cranelift-native = { path = "cranelift-native", version = "0.42.0" }
+cranelift-filetests = { path = "cranelift-filetests", version = "0.42.0" }
+cranelift-module = { path = "cranelift-module", version = "0.42.0" }
+cranelift-faerie = { path = "cranelift-faerie", version = "0.42.0" }
+cranelift-simplejit = { path = "cranelift-simplejit", version = "0.42.0" }
+cranelift-preopt = { path = "cranelift-preopt", version = "0.42.0" }
+cranelift = { path = "cranelift-umbrella", version = "0.42.0" }
 filecheck = "0.4.0"
 clap = "2.32.0"
 serde = "1.0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ serde = "1.0.8"
 term = "0.6.1"
 capstone = { version = "0.6.0", optional = true }
 wabt = { version = "0.9.1", optional = true }
-target-lexicon = "0.8.0"
+target-lexicon = "0.8.1"
 pretty_env_logger = "0.3.0"
 file-per-thread-logger = "0.1.2"
 indicatif = "0.11.0"

--- a/cranelift-bforest/Cargo.toml
+++ b/cranelift-bforest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bforest"
-version = "0.41.0"
+version = "0.42.0"
 description = "A forest of B+-trees"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://cranelift.readthedocs.io/"
@@ -12,7 +12,7 @@ keywords = ["btree", "forest", "set", "map"]
 edition = "2018"
 
 [dependencies]
-cranelift-entity = { path = "../cranelift-entity", version = "0.41.0", default-features = false }
+cranelift-entity = { path = "../cranelift-entity", version = "0.42.0", default-features = false }
 
 [features]
 default = ["std"]

--- a/cranelift-codegen/Cargo.toml
+++ b/cranelift-codegen/Cargo.toml
@@ -21,6 +21,7 @@ hashmap_core = { version = "0.1.9", optional = true }
 target-lexicon = "0.8.1"
 log = { version = "0.4.6", default-features = false }
 serde = { version = "1.0.94", features = ["derive"], optional = true }
+smallvec = { version = "0.6.10" }
 # It is a goal of the cranelift-codegen crate to have minimal external dependencies.
 # Please don't add any unless they are essential to the task of creating binary
 # machine code. Integration tests that need external dependencies can be

--- a/cranelift-codegen/Cargo.toml
+++ b/cranelift-codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen"
-version = "0.41.0"
+version = "0.42.0"
 description = "Low-level code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://cranelift.readthedocs.io/"
@@ -13,8 +13,8 @@ build = "build.rs"
 edition = "2018"
 
 [dependencies]
-cranelift-entity = { path = "../cranelift-entity", version = "0.41.0", default-features = false }
-cranelift-bforest = { path = "../cranelift-bforest", version = "0.41.0", default-features = false }
+cranelift-entity = { path = "../cranelift-entity", version = "0.42.0", default-features = false }
+cranelift-bforest = { path = "../cranelift-bforest", version = "0.42.0", default-features = false }
 failure = { version = "0.1.1", default-features = false, features = ["derive"] }
 failure_derive = { version = "0.1.1", default-features = false }
 hashmap_core = { version = "0.1.9", optional = true }
@@ -27,7 +27,7 @@ serde = { version = "1.0.94", features = ["derive"], optional = true }
 # accomodated in `tests`.
 
 [build-dependencies]
-cranelift-codegen-meta = { path = "meta", version = "0.41.0", default-features = false }
+cranelift-codegen-meta = { path = "meta", version = "0.42.0", default-features = false }
 
 [features]
 default = ["std"]

--- a/cranelift-codegen/Cargo.toml
+++ b/cranelift-codegen/Cargo.toml
@@ -18,7 +18,7 @@ cranelift-bforest = { path = "../cranelift-bforest", version = "0.42.0", default
 failure = { version = "0.1.1", default-features = false, features = ["derive"] }
 failure_derive = { version = "0.1.1", default-features = false }
 hashmap_core = { version = "0.1.9", optional = true }
-target-lexicon = "0.8.0"
+target-lexicon = "0.8.1"
 log = { version = "0.4.6", default-features = false }
 serde = { version = "1.0.94", features = ["derive"], optional = true }
 # It is a goal of the cranelift-codegen crate to have minimal external dependencies.

--- a/cranelift-codegen/meta/Cargo.toml
+++ b/cranelift-codegen/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-codegen-meta"
 authors = ["The Cranelift Project Developers"]
-version = "0.41.0"
+version = "0.42.0"
 description = "Metaprogram for cranelift-codegen code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/CraneStation/cranelift"
@@ -9,7 +9,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-entity = { path = "../../cranelift-entity", version = "0.41.0", default-features = false }
+cranelift-entity = { path = "../../cranelift-entity", version = "0.42.0", default-features = false }
 
 [badges]
 maintenance = { status = "experimental" }

--- a/cranelift-codegen/meta/src/cdsl/ast.rs
+++ b/cranelift-codegen/meta/src/cdsl/ast.rs
@@ -11,7 +11,6 @@ use std::fmt;
 pub enum Expr {
     Var(VarIndex),
     Literal(Literal),
-    Apply(Apply),
 }
 
 impl Expr {
@@ -39,7 +38,6 @@ impl Expr {
         match self {
             Expr::Var(var_index) => var_pool.get(*var_index).to_rust_code(),
             Expr::Literal(literal) => literal.to_rust_code(),
-            Expr::Apply(a) => a.to_rust_code(var_pool),
         }
     }
 }
@@ -80,9 +78,6 @@ impl DefPool {
     }
     pub fn get(&self, index: DefIndex) -> &Def {
         self.pool.get(index).unwrap()
-    }
-    pub fn get_mut(&mut self, index: DefIndex) -> &mut Def {
-        self.pool.get_mut(index).unwrap()
     }
     pub fn next_index(&self) -> DefIndex {
         self.pool.next_key()
@@ -428,16 +423,6 @@ impl Apply {
         let inst_name = inst_and_bound_types.join(".");
 
         format!("{}({})", inst_name, args)
-    }
-
-    fn to_rust_code(&self, var_pool: &VarPool) -> String {
-        let args = self
-            .args
-            .iter()
-            .map(|arg| arg.to_rust_code(var_pool))
-            .collect::<Vec<_>>()
-            .join(", ");
-        format!("{}({})", self.inst.name, args)
     }
 
     pub fn inst_predicate(

--- a/cranelift-codegen/meta/src/cdsl/ast.rs
+++ b/cranelift-codegen/meta/src/cdsl/ast.rs
@@ -8,6 +8,7 @@ use cranelift_entity::{entity_impl, PrimaryMap};
 
 use std::fmt;
 
+#[derive(Debug)]
 pub enum Expr {
     Var(VarIndex),
     Literal(Literal),
@@ -363,6 +364,7 @@ impl VarPool {
 ///
 /// An `Apply` AST expression is created by using function call syntax on instructions. This
 /// applies to both bound and unbound polymorphic instructions.
+#[derive(Debug)]
 pub struct Apply {
     pub inst: Instruction,
     pub args: Vec<Expr>,

--- a/cranelift-codegen/meta/src/cdsl/encodings.rs
+++ b/cranelift-codegen/meta/src/cdsl/encodings.rs
@@ -1,5 +1,4 @@
-use std::rc::Rc;
-
+use crate::cdsl::formats::FormatRegistry;
 use crate::cdsl::instructions::{
     InstSpec, Instruction, InstructionPredicate, InstructionPredicateNode,
     InstructionPredicateNumber, InstructionPredicateRegistry, ValueTypeOrAny,
@@ -7,6 +6,8 @@ use crate::cdsl::instructions::{
 use crate::cdsl::recipes::{EncodingRecipeNumber, Recipes};
 use crate::cdsl::settings::SettingPredicateNumber;
 use crate::cdsl::types::ValueType;
+use std::rc::Rc;
+use std::string::ToString;
 
 /// Encoding for a concrete instruction.
 ///
@@ -61,19 +62,25 @@ pub struct EncodingBuilder {
 }
 
 impl EncodingBuilder {
-    pub fn new(inst: InstSpec, recipe: EncodingRecipeNumber, encbits: u16) -> Self {
+    pub fn new(
+        inst: InstSpec,
+        recipe: EncodingRecipeNumber,
+        encbits: u16,
+        formats: &FormatRegistry,
+    ) -> Self {
         let (inst_predicate, bound_type) = match &inst {
             InstSpec::Bound(inst) => {
                 let other_typevars = &inst.inst.polymorphic_info.as_ref().unwrap().other_typevars;
 
-                assert!(
-                    inst.value_types.len() == other_typevars.len() + 1,
+                assert_eq!(
+                    inst.value_types.len(),
+                    other_typevars.len() + 1,
                     "partially bound polymorphic instruction"
                 );
 
                 // Add secondary type variables to the instruction predicate.
                 let value_types = &inst.value_types;
-                let mut inst_predicate = None;
+                let mut inst_predicate: Option<InstructionPredicate> = None;
                 for (typevar, value_type) in other_typevars.iter().zip(value_types.iter().skip(1)) {
                     let value_type = match value_type {
                         ValueTypeOrAny::Any => continue,
@@ -82,6 +89,24 @@ impl EncodingBuilder {
                     let type_predicate =
                         InstructionPredicate::new_typevar_check(&inst.inst, typevar, value_type);
                     inst_predicate = Some(type_predicate.into());
+                }
+
+                // Add immediate value predicates
+                for (immediate_value, immediate_operand) in inst
+                    .immediate_values
+                    .iter()
+                    .zip(inst.inst.operands_in.iter().filter(|o| o.is_immediate()))
+                {
+                    let immediate_predicate = InstructionPredicate::new_is_field_equal(
+                        formats.get(inst.inst.format),
+                        immediate_operand.name,
+                        immediate_value.to_string(),
+                    );
+                    inst_predicate = if let Some(type_predicate) = inst_predicate {
+                        Some(type_predicate.and(immediate_predicate))
+                    } else {
+                        Some(immediate_predicate.into())
+                    }
                 }
 
                 let ctrl_type = value_types[0]

--- a/cranelift-codegen/meta/src/cdsl/formats.rs
+++ b/cranelift-codegen/meta/src/cdsl/formats.rs
@@ -89,27 +89,6 @@ pub struct InstructionFormatBuilder {
     typevar_operand: Option<usize>,
 }
 
-pub struct ImmParameter {
-    kind: OperandKind,
-    member: &'static str,
-}
-impl Into<ImmParameter> for (&'static str, &OperandKind) {
-    fn into(self) -> ImmParameter {
-        ImmParameter {
-            kind: self.1.clone(),
-            member: self.0,
-        }
-    }
-}
-impl Into<ImmParameter> for &OperandKind {
-    fn into(self) -> ImmParameter {
-        ImmParameter {
-            kind: self.clone(),
-            member: self.default_member.unwrap(),
-        }
-    }
-}
-
 impl InstructionFormatBuilder {
     pub fn new(name: &'static str) -> Self {
         Self {
@@ -131,12 +110,21 @@ impl InstructionFormatBuilder {
         self
     }
 
-    pub fn imm(mut self, param: impl Into<ImmParameter>) -> Self {
-        let imm_param = param.into();
+    pub fn imm(mut self, operand_kind: &OperandKind) -> Self {
         let field = FormatField {
             immnum: self.imm_fields.len(),
-            kind: imm_param.kind,
-            member: imm_param.member,
+            kind: operand_kind.clone(),
+            member: operand_kind.default_member.unwrap(),
+        };
+        self.imm_fields.push(field);
+        self
+    }
+
+    pub fn imm_with_name(mut self, member: &'static str, operand_kind: &OperandKind) -> Self {
+        let field = FormatField {
+            immnum: self.imm_fields.len(),
+            kind: operand_kind.clone(),
+            member,
         };
         self.imm_fields.push(field);
         self

--- a/cranelift-codegen/meta/src/cdsl/formats.rs
+++ b/cranelift-codegen/meta/src/cdsl/formats.rs
@@ -189,7 +189,9 @@ impl FormatRegistry {
             if operand.is_value() {
                 num_values += 1;
             }
-            has_varargs = has_varargs || operand.is_varargs();
+            if !has_varargs {
+                has_varargs = operand.is_varargs();
+            }
             if let Some(imm_key) = operand.kind.imm_key() {
                 imm_keys.push(imm_key);
             }

--- a/cranelift-codegen/meta/src/cdsl/formats.rs
+++ b/cranelift-codegen/meta/src/cdsl/formats.rs
@@ -12,9 +12,6 @@ use cranelift_entity::{entity_impl, PrimaryMap};
 /// data type.
 #[derive(Debug)]
 pub struct FormatField {
-    /// Immediate operand number in parent.
-    immnum: usize,
-
     /// Immediate operand kind.
     pub kind: OperandKind,
 
@@ -53,7 +50,7 @@ pub struct InstructionFormat {
 
 impl fmt::Display for InstructionFormat {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        let args = self
+        let imm_args = self
             .imm_fields
             .iter()
             .map(|field| format!("{}: {}", field.member, field.kind.name))
@@ -61,7 +58,7 @@ impl fmt::Display for InstructionFormat {
             .join(", ");
         fmt.write_fmt(format_args!(
             "{}(imms=({}), vals={})",
-            self.name, args, self.num_value_operands
+            self.name, imm_args, self.num_value_operands
         ))?;
         Ok(())
     }
@@ -112,7 +109,6 @@ impl InstructionFormatBuilder {
 
     pub fn imm(mut self, operand_kind: &OperandKind) -> Self {
         let field = FormatField {
-            immnum: self.imm_fields.len(),
             kind: operand_kind.clone(),
             member: operand_kind.default_member.unwrap(),
         };
@@ -122,7 +118,6 @@ impl InstructionFormatBuilder {
 
     pub fn imm_with_name(mut self, member: &'static str, operand_kind: &OperandKind) -> Self {
         let field = FormatField {
-            immnum: self.imm_fields.len(),
             kind: operand_kind.clone(),
             member,
         };

--- a/cranelift-codegen/meta/src/cdsl/instructions.rs
+++ b/cranelift-codegen/meta/src/cdsl/instructions.rs
@@ -79,12 +79,14 @@ impl InstructionGroup {
     }
 }
 
+#[derive(Debug)]
 pub struct PolymorphicInfo {
     pub use_typevar_operand: bool,
     pub ctrl_typevar: TypeVar,
     pub other_typevars: Vec<TypeVar>,
 }
 
+#[derive(Debug)]
 pub struct InstructionContent {
     /// Instruction mnemonic, also becomes opcode name.
     pub name: String,
@@ -139,7 +141,7 @@ pub struct InstructionContent {
     pub writes_cpu_flags: bool,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Instruction {
     content: Rc<InstructionContent>,
 }

--- a/cranelift-codegen/meta/src/cdsl/instructions.rs
+++ b/cranelift-codegen/meta/src/cdsl/instructions.rs
@@ -492,24 +492,26 @@ impl BoundInstruction {
     /// Verify that the bindings for a BoundInstruction are correct.
     fn verify_bindings(&self) -> Result<(), String> {
         // Verify that binding types to the instruction does not violate the polymorphic rules.
-        match &self.inst.polymorphic_info {
-            Some(poly) => {
-                if self.value_types.len() > 1 + poly.other_typevars.len() {
+        if !self.value_types.is_empty() {
+            match &self.inst.polymorphic_info {
+                Some(poly) => {
+                    if self.value_types.len() > 1 + poly.other_typevars.len() {
+                        return Err(format!(
+                            "trying to bind too many types for {}",
+                            self.inst.name
+                        ));
+                    }
+                }
+                None => {
                     return Err(format!(
-                        "trying to bind too many types for {}",
+                        "trying to bind a type for {} which is not a polymorphic instruction",
                         self.inst.name
                     ));
                 }
             }
-            None => {
-                return Err(format!(
-                    "trying to bind a type for {} which is not a polymorphic instruction",
-                    self.inst.name
-                ))
-            }
         }
 
-        // Verify that too many immediates are not bound.
+        // Verify that only the right number of immediates are bound.
         let immediate_count = self
             .inst
             .operands_in
@@ -559,7 +561,7 @@ impl Bindable for BoundInstruction {
                 modified.immediate_values.push(immediate)
             }
         }
-        self.verify_bindings().unwrap();
+        modified.verify_bindings().unwrap();
         modified
     }
 }
@@ -1197,5 +1199,78 @@ impl Into<InstSpec> for &Instruction {
 impl Into<InstSpec> for BoundInstruction {
     fn into(self) -> InstSpec {
         InstSpec::Bound(self)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::cdsl::formats::InstructionFormatBuilder;
+    use crate::cdsl::operands::{OperandBuilder, OperandKindBuilder, OperandKindFields};
+    use crate::cdsl::typevar::TypeSetBuilder;
+    use crate::shared::types::Int::I32;
+
+    fn field_to_operand(index: usize, field: OperandKindFields) -> Operand {
+        // pretend the index string is &'static
+        let name = Box::leak(index.to_string().into_boxed_str());
+        let kind = OperandKindBuilder::new(name, field).build();
+        let operand = OperandBuilder::new(name, kind).build();
+        operand
+    }
+
+    fn field_to_operands(types: Vec<OperandKindFields>) -> Vec<Operand> {
+        types
+            .iter()
+            .enumerate()
+            .map(|(i, f)| field_to_operand(i, f.clone()))
+            .collect()
+    }
+
+    fn build_fake_instruction(
+        inputs: Vec<OperandKindFields>,
+        outputs: Vec<OperandKindFields>,
+    ) -> Instruction {
+        // setup a format from the input operands
+        let mut formats = FormatRegistry::new();
+        let mut format = InstructionFormatBuilder::new("fake");
+        for (i, f) in inputs.iter().enumerate() {
+            match f {
+                OperandKindFields::TypeVar(_) => format = format.value(),
+                OperandKindFields::ImmValue => {
+                    format = format.imm(&field_to_operand(i, f.clone()).kind)
+                }
+                _ => {}
+            };
+        }
+        formats.insert(format);
+
+        // create the
+        InstructionBuilder::new("fake", "A fake instruction for testing.")
+            .operands_in(field_to_operands(inputs).iter().collect())
+            .operands_out(field_to_operands(outputs).iter().collect())
+            .build(&formats, OpcodeNumber(42))
+    }
+
+    #[test]
+    fn ensure_bound_instructions_can_bind_lane_types() {
+        let type1 = TypeSetBuilder::new().ints(8..64).build();
+        let in1 = OperandKindFields::TypeVar(TypeVar::new("a", "...", type1));
+        let inst = build_fake_instruction(vec![in1], vec![]);
+        let bound_inst = inst.bind(LaneType::IntType(I32));
+    }
+
+    #[test]
+    fn ensure_bound_instructions_can_bind_immediates() {
+        let inst = build_fake_instruction(vec![OperandKindFields::ImmValue], vec![]);
+        let bound_inst = inst.bind(Immediate::UInt8(42));
+        assert!(bound_inst.verify_bindings().is_ok());
+    }
+
+    #[test]
+    #[should_panic]
+    fn ensure_instructions_fail_to_bind() {
+        let inst = build_fake_instruction(vec![], vec![]);
+        inst.bind(InstructionParameter::LaneType(LaneType::IntType(I32)));
+        // trying to bind to an instruction with no inputs should fail
     }
 }

--- a/cranelift-codegen/meta/src/cdsl/instructions.rs
+++ b/cranelift-codegen/meta/src/cdsl/instructions.rs
@@ -13,6 +13,7 @@ use crate::cdsl::operands::Operand;
 use crate::cdsl::type_inference::Constraint;
 use crate::cdsl::types::{LaneType, ReferenceType, ValueType, VectorType};
 use crate::cdsl::typevar::TypeVar;
+use crate::{cdsl, shared};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct OpcodeNumber(u32);
@@ -76,6 +77,36 @@ impl InstructionGroup {
             .iter()
             .find(|inst| &inst.name == name)
             .expect(&format!("unexisting instruction with name {}", name))
+    }
+}
+
+/// Instructions can have parameters bound to them to specialize them for more specific encodings
+/// (e.g. the encoding for adding two float types may be different than than that of adding two
+/// integer types)
+pub trait Bindable {
+    /// Bind a parameter to an instruction
+    fn bind(&self, parameter: impl Into<InstructionParameter>) -> BoundInstruction;
+
+    // TODO remove below
+    fn bind_ref(&self, parameter: shared::types::Reference) -> BoundInstruction {
+        self.bind(InstructionParameter::ReferenceType(ReferenceType(
+            parameter,
+        )))
+    }
+
+    fn bind_vector_from_lane(
+        &self,
+        parameter: impl Into<LaneType>,
+        vector_size: VectorBitWidth,
+    ) -> BoundInstruction {
+        self.bind(InstructionParameter::VectorType(
+            parameter.into(),
+            vector_size,
+        ))
+    }
+
+    fn bind_any(&self) -> BoundInstruction {
+        self.bind(InstructionParameter::AnyType)
     }
 }
 
@@ -172,30 +203,11 @@ impl Instruction {
             None => Vec::new(),
         }
     }
+}
 
-    pub fn bind(&self, lane_type: impl Into<LaneType>) -> BoundInstruction {
-        bind(self.clone(), Some(lane_type.into()), Vec::new())
-    }
-
-    pub fn bind_ref(&self, reference_type: impl Into<ReferenceType>) -> BoundInstruction {
-        bind_ref(self.clone(), Some(reference_type.into()), Vec::new())
-    }
-
-    pub fn bind_vector_from_lane(
-        &self,
-        lane_type: impl Into<LaneType>,
-        vector_size_in_bits: u64,
-    ) -> BoundInstruction {
-        bind_vector(
-            self.clone(),
-            lane_type.into(),
-            vector_size_in_bits,
-            Vec::new(),
-        )
-    }
-
-    pub fn bind_any(&self) -> BoundInstruction {
-        bind(self.clone(), None, Vec::new())
+impl Bindable for Instruction {
+    fn bind(&self, parameter: impl Into<InstructionParameter>) -> BoundInstruction {
+        BoundInstruction::new(self).bind(parameter)
     }
 }
 
@@ -406,6 +418,38 @@ impl ValueTypeOrAny {
     }
 }
 
+type VectorBitWidth = u64;
+pub enum InstructionParameter {
+    AnyType,
+    LaneType(LaneType),
+    VectorType(LaneType, VectorBitWidth),
+    ReferenceType(ReferenceType),
+}
+
+impl From<shared::types::Int> for InstructionParameter {
+    fn from(ty: shared::types::Int) -> Self {
+        InstructionParameter::LaneType(ty.into())
+    }
+}
+
+impl From<shared::types::Bool> for InstructionParameter {
+    fn from(ty: shared::types::Bool) -> Self {
+        InstructionParameter::LaneType(ty.into())
+    }
+}
+
+impl From<shared::types::Float> for InstructionParameter {
+    fn from(ty: shared::types::Float) -> Self {
+        InstructionParameter::LaneType(ty.into())
+    }
+}
+
+impl From<cdsl::types::LaneType> for InstructionParameter {
+    fn from(ty: cdsl::types::LaneType) -> Self {
+        InstructionParameter::LaneType(ty.into())
+    }
+}
+
 #[derive(Clone)]
 pub struct BoundInstruction {
     pub inst: Instruction,
@@ -413,29 +457,63 @@ pub struct BoundInstruction {
 }
 
 impl BoundInstruction {
-    pub fn bind(self, lane_type: impl Into<LaneType>) -> BoundInstruction {
-        bind(self.inst, Some(lane_type.into()), self.value_types)
+    /// Construct a new bound instruction (with nothing bound yet) from an instruction
+    fn new(inst: &Instruction) -> Self {
+        BoundInstruction {
+            inst: inst.clone(),
+            value_types: vec![],
+        }
     }
 
-    pub fn bind_ref(self, reference_type: impl Into<ReferenceType>) -> BoundInstruction {
-        bind_ref(self.inst, Some(reference_type.into()), self.value_types)
+    /// Verify that binding types to the instruction does not violate the polymorphic rules.
+    fn verify_polymorphic_binding(&self) -> Result<(), String> {
+        match &self.inst.polymorphic_info {
+            Some(poly) => {
+                if self.value_types.len() <= 1 + poly.other_typevars.len() {
+                    Ok(())
+                } else {
+                    Err(format!(
+                        "trying to bind too many types for {}",
+                        self.inst.name
+                    ))
+                }
+            }
+            None => Err(format!(
+                "trying to bind a type for {} which is not a polymorphic instruction",
+                self.inst.name
+            )),
+        }
     }
+}
 
-    pub fn bind_vector_from_lane(
-        self,
-        lane_type: impl Into<LaneType>,
-        vector_size_in_bits: u64,
-    ) -> BoundInstruction {
-        bind_vector(
-            self.inst,
-            lane_type.into(),
-            vector_size_in_bits,
-            self.value_types,
-        )
-    }
-
-    pub fn bind_any(self) -> BoundInstruction {
-        bind(self.inst, None, self.value_types)
+impl Bindable for BoundInstruction {
+    fn bind(&self, parameter: impl Into<InstructionParameter>) -> BoundInstruction {
+        let mut modified = self.clone();
+        match parameter.into() {
+            InstructionParameter::AnyType => modified.value_types.push(ValueTypeOrAny::Any),
+            InstructionParameter::LaneType(lane_type) => modified
+                .value_types
+                .push(ValueTypeOrAny::ValueType(lane_type.into())),
+            InstructionParameter::VectorType(lane_type, vector_size_in_bits) => {
+                let num_lanes = vector_size_in_bits / lane_type.lane_bits();
+                assert!(
+                    num_lanes >= 2,
+                    "Minimum lane number for bind_vector is 2, found {}.",
+                    num_lanes,
+                );
+                let vector_type = ValueType::Vector(VectorType::new(lane_type, num_lanes));
+                modified
+                    .value_types
+                    .push(ValueTypeOrAny::ValueType(vector_type));
+            }
+            InstructionParameter::ReferenceType(reference_type) => {
+                modified
+                    .value_types
+                    .push(ValueTypeOrAny::ValueType(reference_type.into()));
+            }
+        }
+        self.verify_polymorphic_binding().unwrap();
+        modified
     }
 }
 
@@ -1052,17 +1130,13 @@ impl InstSpec {
             InstSpec::Bound(bound_inst) => &bound_inst.inst,
         }
     }
-    pub fn bind(&self, lane_type: impl Into<LaneType>) -> BoundInstruction {
-        match self {
-            InstSpec::Inst(inst) => inst.bind(lane_type),
-            InstSpec::Bound(inst) => inst.clone().bind(lane_type),
-        }
-    }
+}
 
-    pub fn bind_ref(&self, reference_type: impl Into<ReferenceType>) -> BoundInstruction {
+impl Bindable for InstSpec {
+    fn bind(&self, parameter: impl Into<InstructionParameter>) -> BoundInstruction {
         match self {
-            InstSpec::Inst(inst) => inst.bind_ref(reference_type),
-            InstSpec::Bound(inst) => inst.clone().bind_ref(reference_type),
+            InstSpec::Inst(inst) => inst.bind(parameter),
+            InstSpec::Bound(inst) => inst.bind(parameter),
         }
     }
 }
@@ -1076,82 +1150,5 @@ impl Into<InstSpec> for &Instruction {
 impl Into<InstSpec> for BoundInstruction {
     fn into(self) -> InstSpec {
         InstSpec::Bound(self)
-    }
-}
-
-/// Helper bind reused by {Bound,}Instruction::bind.
-fn bind(
-    inst: Instruction,
-    lane_type: Option<LaneType>,
-    mut value_types: Vec<ValueTypeOrAny>,
-) -> BoundInstruction {
-    match lane_type {
-        Some(lane_type) => {
-            value_types.push(ValueTypeOrAny::ValueType(lane_type.into()));
-        }
-        None => {
-            value_types.push(ValueTypeOrAny::Any);
-        }
-    }
-
-    verify_polymorphic_binding(&inst, &value_types);
-
-    BoundInstruction { inst, value_types }
-}
-
-/// Helper bind for reference types reused by {Bound,}Instruction::bind_ref.
-fn bind_ref(
-    inst: Instruction,
-    reference_type: Option<ReferenceType>,
-    mut value_types: Vec<ValueTypeOrAny>,
-) -> BoundInstruction {
-    match reference_type {
-        Some(reference_type) => {
-            value_types.push(ValueTypeOrAny::ValueType(reference_type.into()));
-        }
-        None => {
-            value_types.push(ValueTypeOrAny::Any);
-        }
-    }
-
-    verify_polymorphic_binding(&inst, &value_types);
-
-    BoundInstruction { inst, value_types }
-}
-
-/// Helper bind for vector types reused by {Bound,}Instruction::bind.
-fn bind_vector(
-    inst: Instruction,
-    lane_type: LaneType,
-    vector_size_in_bits: u64,
-    mut value_types: Vec<ValueTypeOrAny>,
-) -> BoundInstruction {
-    let num_lanes = vector_size_in_bits / lane_type.lane_bits();
-    assert!(
-        num_lanes >= 2,
-        "Minimum lane number for bind_vector is 2, found {}.",
-        num_lanes,
-    );
-    let vector_type = ValueType::Vector(VectorType::new(lane_type, num_lanes));
-    value_types.push(ValueTypeOrAny::ValueType(vector_type));
-    verify_polymorphic_binding(&inst, &value_types);
-    BoundInstruction { inst, value_types }
-}
-
-/// Helper to verify that binding types to the instruction does not violate polymorphic rules
-fn verify_polymorphic_binding(inst: &Instruction, value_types: &Vec<ValueTypeOrAny>) {
-    match &inst.polymorphic_info {
-        Some(poly) => {
-            assert!(
-                value_types.len() <= 1 + poly.other_typevars.len(),
-                format!("trying to bind too many types for {}", inst.name)
-            );
-        }
-        None => {
-            panic!(format!(
-                "trying to bind a type for {} which is not a polymorphic instruction",
-                inst.name
-            ));
-        }
     }
 }

--- a/cranelift-codegen/meta/src/cdsl/instructions.rs
+++ b/cranelift-codegen/meta/src/cdsl/instructions.rs
@@ -1127,6 +1127,11 @@ fn bind_vector(
     mut value_types: Vec<ValueTypeOrAny>,
 ) -> BoundInstruction {
     let num_lanes = vector_size_in_bits / lane_type.lane_bits();
+    assert!(
+        num_lanes >= 2,
+        "Minimum lane number for bind_vector is 2, found {}.",
+        num_lanes,
+    );
     let vector_type = ValueType::Vector(VectorType::new(lane_type, num_lanes));
     value_types.push(ValueTypeOrAny::ValueType(vector_type));
     verify_polymorphic_binding(&inst, &value_types);

--- a/cranelift-codegen/meta/src/cdsl/instructions.rs
+++ b/cranelift-codegen/meta/src/cdsl/instructions.rs
@@ -14,7 +14,7 @@ use crate::cdsl::type_inference::Constraint;
 use crate::cdsl::types::{LaneType, ReferenceType, ValueType, VectorType};
 use crate::cdsl::typevar::TypeVar;
 
-#[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct OpcodeNumber(u32);
 entity_impl!(OpcodeNumber);
 

--- a/cranelift-codegen/meta/src/cdsl/instructions.rs
+++ b/cranelift-codegen/meta/src/cdsl/instructions.rs
@@ -87,14 +87,8 @@ pub trait Bindable {
     /// Bind a parameter to an instruction
     fn bind(&self, parameter: impl Into<InstructionParameter>) -> BoundInstruction;
 
-    // TODO remove below
-    fn bind_ref(&self, parameter: shared::types::Reference) -> BoundInstruction {
-        self.bind(InstructionParameter::ReferenceType(ReferenceType(
-            parameter,
-        )))
-    }
-
-    fn bind_vector_from_lane(
+    /// Helper method for binding vectors of a specific vector bit width
+    fn bind_vector(
         &self,
         parameter: impl Into<LaneType>,
         vector_size: VectorBitWidth,
@@ -103,10 +97,6 @@ pub trait Bindable {
             parameter.into(),
             vector_size,
         ))
-    }
-
-    fn bind_any(&self) -> BoundInstruction {
-        self.bind(InstructionParameter::AnyType)
     }
 }
 
@@ -418,7 +408,10 @@ impl ValueTypeOrAny {
     }
 }
 
+/// The number of bits in the vector
 type VectorBitWidth = u64;
+
+/// An instruction paramater used for binding instructions to specific types or values
 pub enum InstructionParameter {
     AnyType,
     LaneType(LaneType),
@@ -447,6 +440,12 @@ impl From<shared::types::Float> for InstructionParameter {
 impl From<cdsl::types::LaneType> for InstructionParameter {
     fn from(ty: cdsl::types::LaneType) -> Self {
         InstructionParameter::LaneType(ty.into())
+    }
+}
+
+impl From<shared::types::Reference> for InstructionParameter {
+    fn from(ty: shared::types::Reference) -> Self {
+        InstructionParameter::ReferenceType(ty.into())
     }
 }
 

--- a/cranelift-codegen/meta/src/cdsl/instructions.rs
+++ b/cranelift-codegen/meta/src/cdsl/instructions.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 use std::fmt;
 use std::ops;
 use std::rc::Rc;
-use std::slice;
 
 use crate::cdsl::camel_case;
 use crate::cdsl::formats::{
@@ -72,10 +71,6 @@ pub struct InstructionGroup {
 }
 
 impl InstructionGroup {
-    pub fn iter(&self) -> slice::Iter<Instruction> {
-        self.instructions.iter()
-    }
-
     pub fn by_name(&self, name: &'static str) -> &Instruction {
         self.instructions
             .iter()

--- a/cranelift-codegen/meta/src/cdsl/instructions.rs
+++ b/cranelift-codegen/meta/src/cdsl/instructions.rs
@@ -14,6 +14,7 @@ use crate::cdsl::type_inference::Constraint;
 use crate::cdsl::types::{LaneType, ReferenceType, ValueType, VectorType};
 use crate::cdsl::typevar::TypeVar;
 use crate::{cdsl, shared};
+use std::fmt::{Display, Error, Formatter};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct OpcodeNumber(u32);
@@ -417,6 +418,7 @@ pub enum InstructionParameter {
     LaneType(LaneType),
     VectorType(LaneType, VectorBitWidth),
     ReferenceType(ReferenceType),
+    ImmediateValue(Immediate),
 }
 
 impl From<shared::types::Int> for InstructionParameter {
@@ -449,10 +451,32 @@ impl From<shared::types::Reference> for InstructionParameter {
     }
 }
 
+impl From<Immediate> for InstructionParameter {
+    fn from(imm: Immediate) -> Self {
+        InstructionParameter::ImmediateValue(imm)
+    }
+}
+
+#[derive(Clone)]
+pub enum Immediate {
+    UInt8(u8),
+    UInt128(u128),
+}
+
+impl Display for Immediate {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
+        match self {
+            Immediate::UInt8(x) => write!(f, "{}", x),
+            Immediate::UInt128(x) => write!(f, "{}", x),
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct BoundInstruction {
     pub inst: Instruction,
     pub value_types: Vec<ValueTypeOrAny>,
+    pub immediate_values: Vec<Immediate>,
 }
 
 impl BoundInstruction {
@@ -461,27 +485,48 @@ impl BoundInstruction {
         BoundInstruction {
             inst: inst.clone(),
             value_types: vec![],
+            immediate_values: vec![],
         }
     }
 
-    /// Verify that binding types to the instruction does not violate the polymorphic rules.
-    fn verify_polymorphic_binding(&self) -> Result<(), String> {
+    /// Verify that the bindings for a BoundInstruction are correct.
+    fn verify_bindings(&self) -> Result<(), String> {
+        // Verify that binding types to the instruction does not violate the polymorphic rules.
         match &self.inst.polymorphic_info {
             Some(poly) => {
-                if self.value_types.len() <= 1 + poly.other_typevars.len() {
-                    Ok(())
-                } else {
-                    Err(format!(
+                if self.value_types.len() > 1 + poly.other_typevars.len() {
+                    return Err(format!(
                         "trying to bind too many types for {}",
                         self.inst.name
-                    ))
+                    ));
                 }
             }
-            None => Err(format!(
-                "trying to bind a type for {} which is not a polymorphic instruction",
-                self.inst.name
-            )),
+            None => {
+                return Err(format!(
+                    "trying to bind a type for {} which is not a polymorphic instruction",
+                    self.inst.name
+                ))
+            }
         }
+
+        // Verify that too many immediates are not bound.
+        let immediate_count = self
+            .inst
+            .operands_in
+            .iter()
+            .filter(|o| o.is_immediate())
+            .count();
+        if self.immediate_values.len() > immediate_count {
+            return Err(format!(
+                "trying to bind too many immediates ({}) to instruction {} which only expects {} \
+                 immediates",
+                self.immediate_values.len(),
+                self.inst.name,
+                immediate_count
+            ));
+        }
+
+        Ok(())
     }
 }
 
@@ -510,8 +555,11 @@ impl Bindable for BoundInstruction {
                     .value_types
                     .push(ValueTypeOrAny::ValueType(reference_type.into()));
             }
+            InstructionParameter::ImmediateValue(immediate) => {
+                modified.immediate_values.push(immediate)
+            }
         }
-        self.verify_polymorphic_binding().unwrap();
+        self.verify_bindings().unwrap();
         modified
     }
 }

--- a/cranelift-codegen/meta/src/cdsl/regs.rs
+++ b/cranelift-codegen/meta/src/cdsl/regs.rs
@@ -11,6 +11,7 @@ pub struct RegBank {
     pub names: Vec<&'static str>,
     pub prefix: &'static str,
     pub pressure_tracking: bool,
+    pub pinned_reg: Option<u16>,
     pub toprcs: Vec<RegClassIndex>,
     pub classes: Vec<RegClassIndex>,
 }
@@ -23,6 +24,7 @@ impl RegBank {
         names: Vec<&'static str>,
         prefix: &'static str,
         pressure_tracking: bool,
+        pinned_reg: Option<u16>,
     ) -> Self {
         RegBank {
             name,
@@ -31,6 +33,7 @@ impl RegBank {
             names,
             prefix,
             pressure_tracking,
+            pinned_reg,
             toprcs: Vec::new(),
             classes: Vec::new(),
         }
@@ -183,6 +186,7 @@ pub struct RegBankBuilder {
     pub names: Vec<&'static str>,
     pub prefix: &'static str,
     pub pressure_tracking: Option<bool>,
+    pub pinned_reg: Option<u16>,
 }
 
 impl RegBankBuilder {
@@ -193,6 +197,7 @@ impl RegBankBuilder {
             names: vec![],
             prefix,
             pressure_tracking: None,
+            pinned_reg: None,
         }
     }
     pub fn units(mut self, units: u8) -> Self {
@@ -205,6 +210,11 @@ impl RegBankBuilder {
     }
     pub fn track_pressure(mut self, track: bool) -> Self {
         self.pressure_tracking = Some(track);
+        self
+    }
+    pub fn pinned_reg(mut self, unit: u16) -> Self {
+        assert!(unit < (self.units as u16));
+        self.pinned_reg = Some(unit);
         self
     }
 }
@@ -246,6 +256,7 @@ impl IsaRegsBuilder {
             builder
                 .pressure_tracking
                 .expect("Pressure tracking must be explicitly set"),
+            builder.pinned_reg,
         ))
     }
 

--- a/cranelift-codegen/meta/src/cdsl/type_inference.rs
+++ b/cranelift-codegen/meta/src/cdsl/type_inference.rs
@@ -4,7 +4,7 @@ use crate::cdsl::typevar::{DerivedFunc, TypeSet, TypeVar};
 use std::collections::{HashMap, HashSet};
 use std::iter::FromIterator;
 
-#[derive(Hash, PartialEq, Eq)]
+#[derive(Debug, Hash, PartialEq, Eq)]
 pub enum Constraint {
     /// Constraint specifying that a type var tv1 must be wider than or equal to type var tv2 at
     /// runtime. This requires that:

--- a/cranelift-codegen/meta/src/cdsl/types.rs
+++ b/cranelift-codegen/meta/src/cdsl/types.rs
@@ -215,13 +215,14 @@ impl LaneType {
                 LaneType::BoolType(shared_types::Bool::B16) => 2,
                 LaneType::BoolType(shared_types::Bool::B32) => 3,
                 LaneType::BoolType(shared_types::Bool::B64) => 4,
-                LaneType::IntType(shared_types::Int::I8) => 5,
-                LaneType::IntType(shared_types::Int::I16) => 6,
-                LaneType::IntType(shared_types::Int::I32) => 7,
-                LaneType::IntType(shared_types::Int::I64) => 8,
-                LaneType::IntType(shared_types::Int::I128) => 9,
-                LaneType::FloatType(shared_types::Float::F32) => 10,
-                LaneType::FloatType(shared_types::Float::F64) => 11,
+                LaneType::BoolType(shared_types::Bool::B128) => 5,
+                LaneType::IntType(shared_types::Int::I8) => 6,
+                LaneType::IntType(shared_types::Int::I16) => 7,
+                LaneType::IntType(shared_types::Int::I32) => 8,
+                LaneType::IntType(shared_types::Int::I64) => 9,
+                LaneType::IntType(shared_types::Int::I128) => 10,
+                LaneType::FloatType(shared_types::Float::F32) => 11,
+                LaneType::FloatType(shared_types::Float::F64) => 12,
             }
     }
 
@@ -232,6 +233,7 @@ impl LaneType {
             16 => shared_types::Bool::B16,
             32 => shared_types::Bool::B32,
             64 => shared_types::Bool::B64,
+            128 => shared_types::Bool::B128,
             _ => unreachable!("unxpected num bits for bool"),
         })
     }

--- a/cranelift-codegen/meta/src/cdsl/types.rs
+++ b/cranelift-codegen/meta/src/cdsl/types.rs
@@ -219,8 +219,9 @@ impl LaneType {
                 LaneType::IntType(shared_types::Int::I16) => 6,
                 LaneType::IntType(shared_types::Int::I32) => 7,
                 LaneType::IntType(shared_types::Int::I64) => 8,
-                LaneType::FloatType(shared_types::Float::F32) => 9,
-                LaneType::FloatType(shared_types::Float::F64) => 10,
+                LaneType::IntType(shared_types::Int::I128) => 9,
+                LaneType::FloatType(shared_types::Float::F32) => 10,
+                LaneType::FloatType(shared_types::Float::F64) => 11,
             }
     }
 
@@ -241,6 +242,7 @@ impl LaneType {
             16 => shared_types::Int::I16,
             32 => shared_types::Int::I32,
             64 => shared_types::Int::I64,
+            128 => shared_types::Int::I128,
             _ => unreachable!("unxpected num bits for int"),
         })
     }

--- a/cranelift-codegen/meta/src/cdsl/typevar.rs
+++ b/cranelift-codegen/meta/src/cdsl/typevar.rs
@@ -9,7 +9,7 @@ use std::rc::Rc;
 use crate::cdsl::types::{BVType, LaneType, ReferenceType, SpecialType, ValueType};
 
 const MAX_LANES: u16 = 256;
-const MAX_BITS: u16 = 64;
+const MAX_BITS: u16 = 128;
 const MAX_BITVEC: u16 = MAX_BITS * MAX_LANES;
 
 /// Type variables can be used in place of concrete types when defining

--- a/cranelift-codegen/meta/src/cdsl/xform.rs
+++ b/cranelift-codegen/meta/src/cdsl/xform.rs
@@ -384,9 +384,6 @@ impl TransformGroups {
     pub fn get(&self, id: TransformGroupIndex) -> &TransformGroup {
         &self.groups[id]
     }
-    pub fn get_mut(&mut self, id: TransformGroupIndex) -> &mut TransformGroup {
-        self.groups.get_mut(id).unwrap()
-    }
     fn next_key(&self) -> TransformGroupIndex {
         self.groups.next_key()
     }

--- a/cranelift-codegen/meta/src/cdsl/xform.rs
+++ b/cranelift-codegen/meta/src/cdsl/xform.rs
@@ -183,7 +183,12 @@ fn rewrite_expr(
     assert_eq!(
         apply_target.inst().operands_in.len(),
         dummy_args.len(),
-        "number of arguments in instruction is incorrect"
+        "number of arguments in instruction {} is incorrect\nexpected: {:?}",
+        apply_target.inst().name,
+        apply_target.inst().operands_in
+            .iter()
+            .map(|operand| format!("{}: {}", operand.name, operand.kind.name))
+            .collect::<Vec<_>>(),
     );
 
     let mut args = Vec::new();

--- a/cranelift-codegen/meta/src/cdsl/xform.rs
+++ b/cranelift-codegen/meta/src/cdsl/xform.rs
@@ -185,7 +185,9 @@ fn rewrite_expr(
         dummy_args.len(),
         "number of arguments in instruction {} is incorrect\nexpected: {:?}",
         apply_target.inst().name,
-        apply_target.inst().operands_in
+        apply_target
+            .inst()
+            .operands_in
             .iter()
             .map(|operand| format!("{}: {}", operand.name, operand.kind.name))
             .collect::<Vec<_>>(),

--- a/cranelift-codegen/meta/src/gen_encodings.rs
+++ b/cranelift-codegen/meta/src/gen_encodings.rs
@@ -1126,7 +1126,7 @@ fn gen_isa(defs: &SharedDefinitions, isa: &TargetIsa, fmt: &mut Formatter) {
     fmt.line("};");
 }
 
-pub fn generate(
+pub(crate) fn generate(
     defs: &SharedDefinitions,
     isa: &TargetIsa,
     filename: &str,

--- a/cranelift-codegen/meta/src/gen_inst.rs
+++ b/cranelift-codegen/meta/src/gen_inst.rs
@@ -1059,7 +1059,7 @@ fn gen_builder(instructions: &AllInstructions, formats: &FormatRegistry, fmt: &m
     fmt.line("}");
 }
 
-pub fn generate(
+pub(crate) fn generate(
     shared_defs: &SharedDefinitions,
     opcode_filename: &str,
     inst_builder_filename: &str,

--- a/cranelift-codegen/meta/src/gen_legalizer.rs
+++ b/cranelift-codegen/meta/src/gen_legalizer.rs
@@ -61,10 +61,10 @@ fn unwrap_inst(
             fmtln!(fmt, "{},", field.member);
         }
 
-        if iform.num_value_operands == 1 {
-            fmt.line("arg,");
-        } else if iform.has_value_list || iform.num_value_operands > 1 {
+        if iform.has_value_list || iform.num_value_operands > 1 {
             fmt.line("ref args,");
+        } else if iform.num_value_operands == 1 {
+            fmt.line("arg,");
         }
 
         fmt.line("..");
@@ -87,6 +87,11 @@ fn unwrap_inst(
                 } else if op.is_value() {
                     let n = inst.value_opnums.iter().position(|&i| i == op_num).unwrap();
                     fmtln!(fmt, "func.dfg.resolve_aliases(args[{}]),", n);
+                } else if op.is_varargs() {
+                    let n = inst.imm_opnums.iter().chain(inst.value_opnums.iter()).max().map(|n| n + 1).unwrap_or(0);
+                    fmtln!(fmt, "\
+                        args.iter().skip({}).map(|&arg| func.dfg.resolve_aliases(arg)).collect::<Vec<_>>(),\
+                    ", n);
                 }
             }
 
@@ -103,6 +108,14 @@ fn unwrap_inst(
         fmt.line(r#"unreachable!("bad instruction format")"#);
     });
     fmtln!(fmt, "};");
+
+    assert_eq!(inst.operands_in.len(), apply.args.len());
+    for (i, op) in inst.operands_in.iter().enumerate() {
+        if op.is_varargs() {
+            let name = var_pool.get(apply.args[i].maybe_var().expect("vararg without name")).name;
+            fmtln!(fmt, "let {} = &{};", name, name);
+        }
+    }
 
     for &op_num in &inst.value_opnums {
         let arg = &apply.args[op_num];

--- a/cranelift-codegen/meta/src/gen_legalizer.rs
+++ b/cranelift-codegen/meta/src/gen_legalizer.rs
@@ -112,7 +112,9 @@ fn unwrap_inst(
     assert_eq!(inst.operands_in.len(), apply.args.len());
     for (i, op) in inst.operands_in.iter().enumerate() {
         if op.is_varargs() {
-            let name = var_pool.get(apply.args[i].maybe_var().expect("vararg without name")).name;
+            let name = var_pool
+                .get(apply.args[i].maybe_var().expect("vararg without name"))
+                .name;
             fmtln!(fmt, "let {} = &{};", name, name);
         }
     }

--- a/cranelift-codegen/meta/src/gen_legalizer.rs
+++ b/cranelift-codegen/meta/src/gen_legalizer.rs
@@ -415,6 +415,11 @@ fn gen_transform<'a>(
             fmt.line("let removed = pos.remove_inst();");
             fmt.line("debug_assert_eq!(removed, inst);");
         }
+
+        if transform.def_pool.get(transform.src).apply.inst.is_branch {
+            fmt.line("cfg.recompute_ebb(pos.func, pos.current_ebb().unwrap());");
+        }
+
         fmt.line("return true;");
     });
     fmt.line("}");

--- a/cranelift-codegen/meta/src/gen_registers.rs
+++ b/cranelift-codegen/meta/src/gen_registers.rs
@@ -56,6 +56,7 @@ fn gen_regclass(isa: &TargetIsa, reg_class: &RegClass, fmt: &mut Formatter) {
         fmtln!(fmt, "first: {},", reg_bank.first_unit + reg_class.start);
         fmtln!(fmt, "subclasses: {:#x},", reg_class.subclass_mask());
         fmtln!(fmt, "mask: [{}],", mask);
+        fmtln!(fmt, "pinned_reg: {:?},", reg_bank.pinned_reg);
         fmtln!(fmt, "info: &INFO,");
     });
     fmtln!(fmt, "};");

--- a/cranelift-codegen/meta/src/isa/arm32/mod.rs
+++ b/cranelift-codegen/meta/src/isa/arm32/mod.rs
@@ -49,7 +49,7 @@ fn define_regs() -> IsaRegs {
     regs.build()
 }
 
-pub fn define(shared_defs: &mut SharedDefinitions) -> TargetIsa {
+pub(crate) fn define(shared_defs: &mut SharedDefinitions) -> TargetIsa {
     let settings = define_settings(&shared_defs.settings);
     let regs = define_regs();
 

--- a/cranelift-codegen/meta/src/isa/arm64/mod.rs
+++ b/cranelift-codegen/meta/src/isa/arm64/mod.rs
@@ -45,7 +45,7 @@ fn define_registers() -> IsaRegs {
     regs.build()
 }
 
-pub fn define(shared_defs: &mut SharedDefinitions) -> TargetIsa {
+pub(crate) fn define(shared_defs: &mut SharedDefinitions) -> TargetIsa {
     let settings = define_settings(&shared_defs.settings);
     let regs = define_registers();
 

--- a/cranelift-codegen/meta/src/isa/mod.rs
+++ b/cranelift-codegen/meta/src/isa/mod.rs
@@ -55,7 +55,7 @@ impl fmt::Display for Isa {
     }
 }
 
-pub fn define(isas: &Vec<Isa>, shared_defs: &mut SharedDefinitions) -> Vec<TargetIsa> {
+pub(crate) fn define(isas: &Vec<Isa>, shared_defs: &mut SharedDefinitions) -> Vec<TargetIsa> {
     isas.iter()
         .map(|isa| match isa {
             Isa::Riscv => riscv::define(shared_defs),

--- a/cranelift-codegen/meta/src/isa/riscv/encodings.rs
+++ b/cranelift-codegen/meta/src/isa/riscv/encodings.rs
@@ -13,26 +13,33 @@ use crate::shared::types::Reference::{R32, R64};
 use crate::shared::Definitions as SharedDefinitions;
 
 use super::recipes::RecipeGroup;
-
-fn enc(inst: impl Into<InstSpec>, recipe: EncodingRecipeNumber, bits: u16) -> EncodingBuilder {
-    EncodingBuilder::new(inst.into(), recipe, bits)
-}
+use crate::cdsl::formats::FormatRegistry;
 
 pub struct PerCpuModeEncodings<'defs> {
     pub inst_pred_reg: InstructionPredicateRegistry,
     pub enc32: Vec<Encoding>,
     pub enc64: Vec<Encoding>,
     recipes: &'defs Recipes,
+    formats: &'defs FormatRegistry,
 }
 
 impl<'defs> PerCpuModeEncodings<'defs> {
-    fn new(recipes: &'defs Recipes) -> Self {
+    fn new(recipes: &'defs Recipes, formats: &'defs FormatRegistry) -> Self {
         Self {
             inst_pred_reg: InstructionPredicateRegistry::new(),
             enc32: Vec::new(),
             enc64: Vec::new(),
             recipes,
+            formats,
         }
+    }
+    fn enc(
+        &self,
+        inst: impl Into<InstSpec>,
+        recipe: EncodingRecipeNumber,
+        bits: u16,
+    ) -> EncodingBuilder {
+        EncodingBuilder::new(inst.into(), recipe, bits, self.formats)
     }
     fn add32(&mut self, encoding: EncodingBuilder) {
         self.enc32
@@ -169,7 +176,7 @@ pub(crate) fn define<'defs>(
     let use_m = isa_settings.predicate_by_name("use_m");
 
     // Definitions.
-    let mut e = PerCpuModeEncodings::new(&recipes.recipes);
+    let mut e = PerCpuModeEncodings::new(&recipes.recipes, &shared_defs.format_registry);
 
     // Basic arithmetic binary instructions are encoded in an R-type instruction.
     for &(inst, inst_imm, f3, f7) in &[
@@ -179,26 +186,26 @@ pub(crate) fn define<'defs>(
         (bor, Some(bor_imm), 0b110, 0b0000000),
         (band, Some(band_imm), 0b111, 0b0000000),
     ] {
-        e.add32(enc(inst.bind(I32), r_r, op_bits(f3, f7)));
-        e.add64(enc(inst.bind(I64), r_r, op_bits(f3, f7)));
+        e.add32(e.enc(inst.bind(I32), r_r, op_bits(f3, f7)));
+        e.add64(e.enc(inst.bind(I64), r_r, op_bits(f3, f7)));
 
         // Immediate versions for add/xor/or/and.
         if let Some(inst_imm) = inst_imm {
-            e.add32(enc(inst_imm.bind(I32), r_ii, opimm_bits(f3, 0)));
-            e.add64(enc(inst_imm.bind(I64), r_ii, opimm_bits(f3, 0)));
+            e.add32(e.enc(inst_imm.bind(I32), r_ii, opimm_bits(f3, 0)));
+            e.add64(e.enc(inst_imm.bind(I64), r_ii, opimm_bits(f3, 0)));
         }
     }
 
     // 32-bit ops in RV64.
-    e.add64(enc(iadd.bind(I32), r_r, op32_bits(0b000, 0b0000000)));
-    e.add64(enc(isub.bind(I32), r_r, op32_bits(0b000, 0b0100000)));
+    e.add64(e.enc(iadd.bind(I32), r_r, op32_bits(0b000, 0b0000000)));
+    e.add64(e.enc(isub.bind(I32), r_r, op32_bits(0b000, 0b0100000)));
     // There are no andiw/oriw/xoriw variations.
-    e.add64(enc(iadd_imm.bind(I32), r_ii, opimm32_bits(0b000, 0)));
+    e.add64(e.enc(iadd_imm.bind(I32), r_ii, opimm32_bits(0b000, 0)));
 
     // Use iadd_imm with %x0 to materialize constants.
-    e.add32(enc(iconst.bind(I32), r_iz, opimm_bits(0b0, 0)));
-    e.add64(enc(iconst.bind(I32), r_iz, opimm_bits(0b0, 0)));
-    e.add64(enc(iconst.bind(I64), r_iz, opimm_bits(0b0, 0)));
+    e.add32(e.enc(iconst.bind(I32), r_iz, opimm_bits(0b0, 0)));
+    e.add64(e.enc(iconst.bind(I32), r_iz, opimm_bits(0b0, 0)));
+    e.add64(e.enc(iconst.bind(I64), r_iz, opimm_bits(0b0, 0)));
 
     // Dynamic shifts have the same masking semantics as the clif base instructions.
     for &(inst, inst_imm, f3, f7) in &[
@@ -206,17 +213,17 @@ pub(crate) fn define<'defs>(
         (ushr, ushr_imm, 0b101, 0b0),
         (sshr, sshr_imm, 0b101, 0b100000),
     ] {
-        e.add32(enc(inst.bind(I32).bind(I32), r_r, op_bits(f3, f7)));
-        e.add64(enc(inst.bind(I64).bind(I64), r_r, op_bits(f3, f7)));
-        e.add64(enc(inst.bind(I32).bind(I32), r_r, op32_bits(f3, f7)));
+        e.add32(e.enc(inst.bind(I32).bind(I32), r_r, op_bits(f3, f7)));
+        e.add64(e.enc(inst.bind(I64).bind(I64), r_r, op_bits(f3, f7)));
+        e.add64(e.enc(inst.bind(I32).bind(I32), r_r, op32_bits(f3, f7)));
         // Allow i32 shift amounts in 64-bit shifts.
-        e.add64(enc(inst.bind(I64).bind(I32), r_r, op_bits(f3, f7)));
-        e.add64(enc(inst.bind(I32).bind(I64), r_r, op32_bits(f3, f7)));
+        e.add64(e.enc(inst.bind(I64).bind(I32), r_r, op_bits(f3, f7)));
+        e.add64(e.enc(inst.bind(I32).bind(I64), r_r, op32_bits(f3, f7)));
 
         // Immediate shifts.
-        e.add32(enc(inst_imm.bind(I32), r_rshamt, opimm_bits(f3, f7)));
-        e.add64(enc(inst_imm.bind(I64), r_rshamt, opimm_bits(f3, f7)));
-        e.add64(enc(inst_imm.bind(I32), r_rshamt, opimm32_bits(f3, f7)));
+        e.add32(e.enc(inst_imm.bind(I32), r_rshamt, opimm_bits(f3, f7)));
+        e.add64(e.enc(inst_imm.bind(I64), r_rshamt, opimm_bits(f3, f7)));
+        e.add64(e.enc(inst_imm.bind(I32), r_rshamt, opimm32_bits(f3, f7)));
     }
 
     // Signed and unsigned integer 'less than'. There are no 'w' variants for comparing 32-bit
@@ -242,20 +249,20 @@ pub(crate) fn define<'defs>(
         let icmp_i32 = icmp.bind(I32);
         let icmp_i64 = icmp.bind(I64);
         e.add32(
-            enc(icmp_i32.clone(), r_ricmp, op_bits(0b010, 0b0000000))
+            e.enc(icmp_i32.clone(), r_ricmp, op_bits(0b010, 0b0000000))
                 .inst_predicate(icmp_instp(&icmp_i32, "slt")),
         );
         e.add64(
-            enc(icmp_i64.clone(), r_ricmp, op_bits(0b010, 0b0000000))
+            e.enc(icmp_i64.clone(), r_ricmp, op_bits(0b010, 0b0000000))
                 .inst_predicate(icmp_instp(&icmp_i64, "slt")),
         );
 
         e.add32(
-            enc(icmp_i32.clone(), r_ricmp, op_bits(0b011, 0b0000000))
+            e.enc(icmp_i32.clone(), r_ricmp, op_bits(0b011, 0b0000000))
                 .inst_predicate(icmp_instp(&icmp_i32, "ult")),
         );
         e.add64(
-            enc(icmp_i64.clone(), r_ricmp, op_bits(0b011, 0b0000000))
+            e.enc(icmp_i64.clone(), r_ricmp, op_bits(0b011, 0b0000000))
                 .inst_predicate(icmp_instp(&icmp_i64, "ult")),
         );
 
@@ -263,42 +270,51 @@ pub(crate) fn define<'defs>(
         let icmp_i32 = icmp_imm.bind(I32);
         let icmp_i64 = icmp_imm.bind(I64);
         e.add32(
-            enc(icmp_i32.clone(), r_iicmp, opimm_bits(0b010, 0))
+            e.enc(icmp_i32.clone(), r_iicmp, opimm_bits(0b010, 0))
                 .inst_predicate(icmp_instp(&icmp_i32, "slt")),
         );
         e.add64(
-            enc(icmp_i64.clone(), r_iicmp, opimm_bits(0b010, 0))
+            e.enc(icmp_i64.clone(), r_iicmp, opimm_bits(0b010, 0))
                 .inst_predicate(icmp_instp(&icmp_i64, "slt")),
         );
 
         e.add32(
-            enc(icmp_i32.clone(), r_iicmp, opimm_bits(0b011, 0))
+            e.enc(icmp_i32.clone(), r_iicmp, opimm_bits(0b011, 0))
                 .inst_predicate(icmp_instp(&icmp_i32, "ult")),
         );
         e.add64(
-            enc(icmp_i64.clone(), r_iicmp, opimm_bits(0b011, 0))
+            e.enc(icmp_i64.clone(), r_iicmp, opimm_bits(0b011, 0))
                 .inst_predicate(icmp_instp(&icmp_i64, "ult")),
         );
     }
 
     // Integer constants with the low 12 bits clear are materialized by lui.
-    e.add32(enc(iconst.bind(I32), r_u, lui_bits()));
-    e.add64(enc(iconst.bind(I32), r_u, lui_bits()));
-    e.add64(enc(iconst.bind(I64), r_u, lui_bits()));
+    e.add32(e.enc(iconst.bind(I32), r_u, lui_bits()));
+    e.add64(e.enc(iconst.bind(I32), r_u, lui_bits()));
+    e.add64(e.enc(iconst.bind(I64), r_u, lui_bits()));
 
     // "M" Standard Extension for Integer Multiplication and Division.
     // Gated by the `use_m` flag.
-    e.add32(enc(imul.bind(I32), r_r, op_bits(0b000, 0b00000001)).isa_predicate(use_m));
-    e.add64(enc(imul.bind(I64), r_r, op_bits(0b000, 0b00000001)).isa_predicate(use_m));
-    e.add64(enc(imul.bind(I32), r_r, op32_bits(0b000, 0b00000001)).isa_predicate(use_m));
+    e.add32(
+        e.enc(imul.bind(I32), r_r, op_bits(0b000, 0b00000001))
+            .isa_predicate(use_m),
+    );
+    e.add64(
+        e.enc(imul.bind(I64), r_r, op_bits(0b000, 0b00000001))
+            .isa_predicate(use_m),
+    );
+    e.add64(
+        e.enc(imul.bind(I32), r_r, op32_bits(0b000, 0b00000001))
+            .isa_predicate(use_m),
+    );
 
     // Control flow.
 
     // Unconditional branches.
-    e.add32(enc(jump, r_uj, jal_bits()));
-    e.add64(enc(jump, r_uj, jal_bits()));
-    e.add32(enc(call, r_uj_call, jal_bits()));
-    e.add64(enc(call, r_uj_call, jal_bits()));
+    e.add32(e.enc(jump, r_uj, jal_bits()));
+    e.add64(e.enc(jump, r_uj, jal_bits()));
+    e.add32(e.enc(call, r_uj_call, jal_bits()));
+    e.add64(e.enc(call, r_uj_call, jal_bits()));
 
     // Conditional branches.
     {
@@ -338,101 +354,81 @@ pub(crate) fn define<'defs>(
             ("uge", 0b111),
         ] {
             e.add32(
-                enc(br_icmp_i32.clone(), r_sb, branch_bits(f3))
+                e.enc(br_icmp_i32.clone(), r_sb, branch_bits(f3))
                     .inst_predicate(br_icmp_instp(&br_icmp_i32, cond)),
             );
             e.add64(
-                enc(br_icmp_i64.clone(), r_sb, branch_bits(f3))
+                e.enc(br_icmp_i64.clone(), r_sb, branch_bits(f3))
                     .inst_predicate(br_icmp_instp(&br_icmp_i64, cond)),
             );
         }
     }
 
     for &(inst, f3) in &[(brz, 0b000), (brnz, 0b001)] {
-        e.add32(enc(inst.bind(I32), r_sb_zero, branch_bits(f3)));
-        e.add64(enc(inst.bind(I64), r_sb_zero, branch_bits(f3)));
-        e.add32(enc(inst.bind(B1), r_sb_zero, branch_bits(f3)));
-        e.add64(enc(inst.bind(B1), r_sb_zero, branch_bits(f3)));
+        e.add32(e.enc(inst.bind(I32), r_sb_zero, branch_bits(f3)));
+        e.add64(e.enc(inst.bind(I64), r_sb_zero, branch_bits(f3)));
+        e.add32(e.enc(inst.bind(B1), r_sb_zero, branch_bits(f3)));
+        e.add64(e.enc(inst.bind(B1), r_sb_zero, branch_bits(f3)));
     }
 
     // Returns are a special case of jalr_bits using %x1 to hold the return address.
     // The return address is provided by a special-purpose `link` return value that
     // is added by legalize_signature().
-    e.add32(enc(return_, r_iret, jalr_bits()));
-    e.add64(enc(return_, r_iret, jalr_bits()));
-    e.add32(enc(call_indirect.bind(I32), r_icall, jalr_bits()));
-    e.add64(enc(call_indirect.bind(I64), r_icall, jalr_bits()));
+    e.add32(e.enc(return_, r_iret, jalr_bits()));
+    e.add64(e.enc(return_, r_iret, jalr_bits()));
+    e.add32(e.enc(call_indirect.bind(I32), r_icall, jalr_bits()));
+    e.add64(e.enc(call_indirect.bind(I64), r_icall, jalr_bits()));
 
     // Spill and fill.
-    e.add32(enc(spill.bind(I32), r_gp_sp, store_bits(0b010)));
-    e.add64(enc(spill.bind(I32), r_gp_sp, store_bits(0b010)));
-    e.add64(enc(spill.bind(I64), r_gp_sp, store_bits(0b011)));
-    e.add32(enc(fill.bind(I32), r_gp_fi, load_bits(0b010)));
-    e.add64(enc(fill.bind(I32), r_gp_fi, load_bits(0b010)));
-    e.add64(enc(fill.bind(I64), r_gp_fi, load_bits(0b011)));
+    e.add32(e.enc(spill.bind(I32), r_gp_sp, store_bits(0b010)));
+    e.add64(e.enc(spill.bind(I32), r_gp_sp, store_bits(0b010)));
+    e.add64(e.enc(spill.bind(I64), r_gp_sp, store_bits(0b011)));
+    e.add32(e.enc(fill.bind(I32), r_gp_fi, load_bits(0b010)));
+    e.add64(e.enc(fill.bind(I32), r_gp_fi, load_bits(0b010)));
+    e.add64(e.enc(fill.bind(I64), r_gp_fi, load_bits(0b011)));
 
     // No-op fills, created by late-stage redundant-fill removal.
     for &ty in &[I64, I32] {
-        e.add64(enc(fill_nop.bind(ty), r_fillnull, 0));
-        e.add32(enc(fill_nop.bind(ty), r_fillnull, 0));
+        e.add64(e.enc(fill_nop.bind(ty), r_fillnull, 0));
+        e.add32(e.enc(fill_nop.bind(ty), r_fillnull, 0));
     }
-    e.add64(enc(fill_nop.bind(B1), r_fillnull, 0));
-    e.add32(enc(fill_nop.bind(B1), r_fillnull, 0));
+    e.add64(e.enc(fill_nop.bind(B1), r_fillnull, 0));
+    e.add32(e.enc(fill_nop.bind(B1), r_fillnull, 0));
 
     // Register copies.
-    e.add32(enc(copy.bind(I32), r_icopy, opimm_bits(0b000, 0)));
-    e.add64(enc(copy.bind(I64), r_icopy, opimm_bits(0b000, 0)));
-    e.add64(enc(copy.bind(I32), r_icopy, opimm32_bits(0b000, 0)));
+    e.add32(e.enc(copy.bind(I32), r_icopy, opimm_bits(0b000, 0)));
+    e.add64(e.enc(copy.bind(I64), r_icopy, opimm_bits(0b000, 0)));
+    e.add64(e.enc(copy.bind(I32), r_icopy, opimm32_bits(0b000, 0)));
 
-    e.add32(enc(regmove.bind(I32), r_irmov, opimm_bits(0b000, 0)));
-    e.add64(enc(regmove.bind(I64), r_irmov, opimm_bits(0b000, 0)));
-    e.add64(enc(regmove.bind(I32), r_irmov, opimm32_bits(0b000, 0)));
+    e.add32(e.enc(regmove.bind(I32), r_irmov, opimm_bits(0b000, 0)));
+    e.add64(e.enc(regmove.bind(I64), r_irmov, opimm_bits(0b000, 0)));
+    e.add64(e.enc(regmove.bind(I32), r_irmov, opimm32_bits(0b000, 0)));
 
-    e.add32(enc(copy.bind(B1), r_icopy, opimm_bits(0b000, 0)));
-    e.add64(enc(copy.bind(B1), r_icopy, opimm_bits(0b000, 0)));
-    e.add32(enc(regmove.bind(B1), r_irmov, opimm_bits(0b000, 0)));
-    e.add64(enc(regmove.bind(B1), r_irmov, opimm_bits(0b000, 0)));
+    e.add32(e.enc(copy.bind(B1), r_icopy, opimm_bits(0b000, 0)));
+    e.add64(e.enc(copy.bind(B1), r_icopy, opimm_bits(0b000, 0)));
+    e.add32(e.enc(regmove.bind(B1), r_irmov, opimm_bits(0b000, 0)));
+    e.add64(e.enc(regmove.bind(B1), r_irmov, opimm_bits(0b000, 0)));
 
     // Stack-slot-to-the-same-stack-slot copy, which is guaranteed to turn
     // into a no-op.
     // The same encoding is generated for both the 64- and 32-bit architectures.
     for &ty in &[I64, I32, I16, I8] {
-        e.add32(enc(copy_nop.bind(ty), r_stacknull, 0));
-        e.add64(enc(copy_nop.bind(ty), r_stacknull, 0));
+        e.add32(e.enc(copy_nop.bind(ty), r_stacknull, 0));
+        e.add64(e.enc(copy_nop.bind(ty), r_stacknull, 0));
     }
     for &ty in &[F64, F32] {
-        e.add32(enc(copy_nop.bind(ty), r_stacknull, 0));
-        e.add64(enc(copy_nop.bind(ty), r_stacknull, 0));
+        e.add32(e.enc(copy_nop.bind(ty), r_stacknull, 0));
+        e.add64(e.enc(copy_nop.bind(ty), r_stacknull, 0));
     }
 
     // Copy-to-SSA
-    e.add32(enc(
-        copy_to_ssa.bind(I32),
-        r_copytossa,
-        opimm_bits(0b000, 0),
-    ));
-    e.add64(enc(
-        copy_to_ssa.bind(I64),
-        r_copytossa,
-        opimm_bits(0b000, 0),
-    ));
-    e.add64(enc(
-        copy_to_ssa.bind(I32),
-        r_copytossa,
-        opimm32_bits(0b000, 0),
-    ));
-    e.add32(enc(copy_to_ssa.bind(B1), r_copytossa, opimm_bits(0b000, 0)));
-    e.add64(enc(copy_to_ssa.bind(B1), r_copytossa, opimm_bits(0b000, 0)));
-    e.add32(enc(
-        copy_to_ssa.bind(R32),
-        r_copytossa,
-        opimm_bits(0b000, 0),
-    ));
-    e.add64(enc(
-        copy_to_ssa.bind(R64),
-        r_copytossa,
-        opimm_bits(0b000, 0),
-    ));
+    e.add32(e.enc(copy_to_ssa.bind(I32), r_copytossa, opimm_bits(0b000, 0)));
+    e.add64(e.enc(copy_to_ssa.bind(I64), r_copytossa, opimm_bits(0b000, 0)));
+    e.add64(e.enc(copy_to_ssa.bind(I32), r_copytossa, opimm32_bits(0b000, 0)));
+    e.add32(e.enc(copy_to_ssa.bind(B1), r_copytossa, opimm_bits(0b000, 0)));
+    e.add64(e.enc(copy_to_ssa.bind(B1), r_copytossa, opimm_bits(0b000, 0)));
+    e.add32(e.enc(copy_to_ssa.bind(R32), r_copytossa, opimm_bits(0b000, 0)));
+    e.add64(e.enc(copy_to_ssa.bind(R64), r_copytossa, opimm_bits(0b000, 0)));
 
     e
 }

--- a/cranelift-codegen/meta/src/isa/riscv/encodings.rs
+++ b/cranelift-codegen/meta/src/isa/riscv/encodings.rs
@@ -1,7 +1,7 @@
 use crate::cdsl::ast::{Apply, Expr, Literal, VarPool};
 use crate::cdsl::encodings::{Encoding, EncodingBuilder};
 use crate::cdsl::instructions::{
-    BoundInstruction, InstSpec, InstructionPredicateNode, InstructionPredicateRegistry,
+    Bindable, BoundInstruction, InstSpec, InstructionPredicateNode, InstructionPredicateRegistry,
 };
 use crate::cdsl::recipes::{EncodingRecipeNumber, Recipes};
 use crate::cdsl::settings::SettingGroup;

--- a/cranelift-codegen/meta/src/isa/riscv/encodings.rs
+++ b/cranelift-codegen/meta/src/isa/riscv/encodings.rs
@@ -230,8 +230,7 @@ pub fn define<'defs>(
          -> InstructionPredicateNode {
             let x = var_pool.create("x");
             let y = var_pool.create("y");
-            let cc =
-                Literal::enumerator_for(shared_defs.operand_kinds.by_name("intcc"), intcc_field);
+            let cc = Literal::enumerator_for(&shared_defs.imm.intcc, intcc_field);
             Apply::new(
                 bound_inst.clone().into(),
                 vec![Expr::Literal(cc), Expr::Var(x), Expr::Var(y)],
@@ -313,8 +312,7 @@ pub fn define<'defs>(
             let y = var_pool.create("y");
             let dest = var_pool.create("dest");
             let args = var_pool.create("args");
-            let cc =
-                Literal::enumerator_for(shared_defs.operand_kinds.by_name("intcc"), intcc_field);
+            let cc = Literal::enumerator_for(&shared_defs.imm.intcc, intcc_field);
             Apply::new(
                 bound_inst.clone().into(),
                 vec![

--- a/cranelift-codegen/meta/src/isa/riscv/encodings.rs
+++ b/cranelift-codegen/meta/src/isa/riscv/encodings.rs
@@ -424,12 +424,12 @@ pub(crate) fn define<'defs>(
     e.add32(enc(copy_to_ssa.bind(B1), r_copytossa, opimm_bits(0b000, 0)));
     e.add64(enc(copy_to_ssa.bind(B1), r_copytossa, opimm_bits(0b000, 0)));
     e.add32(enc(
-        copy_to_ssa.bind_ref(R32),
+        copy_to_ssa.bind(R32),
         r_copytossa,
         opimm_bits(0b000, 0),
     ));
     e.add64(enc(
-        copy_to_ssa.bind_ref(R64),
+        copy_to_ssa.bind(R64),
         r_copytossa,
         opimm_bits(0b000, 0),
     ));

--- a/cranelift-codegen/meta/src/isa/riscv/encodings.rs
+++ b/cranelift-codegen/meta/src/isa/riscv/encodings.rs
@@ -101,7 +101,7 @@ fn lui_bits() -> u16 {
     0b01101
 }
 
-pub fn define<'defs>(
+pub(crate) fn define<'defs>(
     shared_defs: &'defs SharedDefinitions,
     isa_settings: &SettingGroup,
     recipes: &'defs RecipeGroup,

--- a/cranelift-codegen/meta/src/isa/riscv/mod.rs
+++ b/cranelift-codegen/meta/src/isa/riscv/mod.rs
@@ -85,7 +85,7 @@ fn define_registers() -> IsaRegs {
     regs.build()
 }
 
-pub fn define(shared_defs: &mut SharedDefinitions) -> TargetIsa {
+pub(crate) fn define(shared_defs: &mut SharedDefinitions) -> TargetIsa {
     let settings = define_settings(&shared_defs.settings);
     let regs = define_registers();
 

--- a/cranelift-codegen/meta/src/isa/riscv/recipes.rs
+++ b/cranelift-codegen/meta/src/isa/riscv/recipes.rs
@@ -50,7 +50,7 @@ impl<'formats> RecipeGroup<'formats> {
     }
 }
 
-pub fn define<'formats>(
+pub(crate) fn define<'formats>(
     shared_defs: &'formats SharedDefinitions,
     regs: &IsaRegs,
 ) -> RecipeGroup<'formats> {

--- a/cranelift-codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift-codegen/meta/src/isa/x86/encodings.rs
@@ -1776,7 +1776,7 @@ pub(crate) fn define(
     insertlane_mapping.insert(32, (vec![0x66, 0x0f, 0x3a, 0x22], Some(use_sse41_simd))); // PINSRD
     insertlane_mapping.insert(64, (vec![0x66, 0x0f, 0x3a, 0x22], Some(use_sse41_simd))); // PINSRQ, only x86_64
 
-    for ty in ValueType::all_lane_types() {
+    for ty in ValueType::all_lane_types().filter(allowed_simd_type) {
         if let Some((opcode, isap)) = insertlane_mapping.get(&ty.lane_bits()) {
             let instruction = insertlane.bind_vector_from_lane(ty, sse_vector_size);
             let template = rec_r_ib_unsigned_r.opcodes(opcode.clone());
@@ -1797,7 +1797,7 @@ pub(crate) fn define(
     extractlane_mapping.insert(32, (vec![0x66, 0x0f, 0x3a, 0x16], Some(use_sse41_simd))); // PEXTRD
     extractlane_mapping.insert(64, (vec![0x66, 0x0f, 0x3a, 0x16], Some(use_sse41_simd))); // PEXTRQ, only x86_64
 
-    for ty in ValueType::all_lane_types() {
+    for ty in ValueType::all_lane_types().filter(allowed_simd_type) {
         if let Some((opcode, isap)) = extractlane_mapping.get(&ty.lane_bits()) {
             let instruction = extractlane.bind_vector_from_lane(ty, sse_vector_size);
             let template = rec_r_ib_unsigned_gpr.opcodes(opcode.clone());

--- a/cranelift-codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift-codegen/meta/src/isa/x86/encodings.rs
@@ -279,7 +279,8 @@ impl PerCpuModeEncodings {
         }
     }
 
-    /// Add the same encoding to both X86_32 and X86_64; assumes configuration (e.g. REX, operand binding) has already happened
+    /// Add the same encoding to both X86_32 and X86_64; assumes configuration (e.g. REX, operand
+    /// binding) has already happened.
     fn enc_32_64_maybe_isap(
         &mut self,
         inst: impl Clone + Into<InstSpec>,

--- a/cranelift-codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift-codegen/meta/src/isa/x86/encodings.rs
@@ -397,6 +397,9 @@ pub fn define(
     let istore8 = shared.by_name("istore8");
     let istore8_complex = shared.by_name("istore8_complex");
     let isub = shared.by_name("isub");
+    let isub_bout = shared.by_name("isub_bout");
+    let isub_bin = shared.by_name("isub_bin");
+    let isub_borrow = shared.by_name("isub_borrow");
     let jump = shared.by_name("jump");
     let jump_table_base = shared.by_name("jump_table_base");
     let jump_table_entry = shared.by_name("jump_table_entry");
@@ -560,8 +563,8 @@ pub fn define(
     let rec_rfurm = r.template("rfurm");
     let rec_rmov = r.template("rmov");
     let rec_rr = r.template("rr");
-    let rec_rcin = r.template("rcin");
-    let rec_rcarry = r.template("rcarry");
+    let rec_rin = r.template("rin");
+    let rec_rio = r.template("rio");
     let rec_rrx = r.template("rrx");
     let rec_safepoint = r.recipe("safepoint");
     let rec_setf_abcd = r.template("setf_abcd");
@@ -618,10 +621,14 @@ pub fn define(
 
     e.enc_i32_i64(iadd, rec_rr.opcodes(vec![0x01]));
     e.enc_i32_i64(iadd_cout, rec_rr.opcodes(vec![0x01]));
-    e.enc_i32_i64(iadd_cin, rec_rcin.opcodes(vec![0x11]));
-    e.enc_i32_i64(iadd_carry, rec_rcarry.opcodes(vec![0x11]));
+    e.enc_i32_i64(iadd_cin, rec_rin.opcodes(vec![0x11]));
+    e.enc_i32_i64(iadd_carry, rec_rio.opcodes(vec![0x11]));
 
     e.enc_i32_i64(isub, rec_rr.opcodes(vec![0x29]));
+    e.enc_i32_i64(isub_bout, rec_rr.opcodes(vec![0x29]));
+    e.enc_i32_i64(isub_bin, rec_rin.opcodes(vec![0x19]));
+    e.enc_i32_i64(isub_borrow, rec_rio.opcodes(vec![0x19]));
+
     e.enc_i32_i64(band, rec_rr.opcodes(vec![0x21]));
     e.enc_i32_i64(bor, rec_rr.opcodes(vec![0x09]));
     e.enc_i32_i64(bxor, rec_rr.opcodes(vec![0x31]));

--- a/cranelift-codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift-codegen/meta/src/isa/x86/encodings.rs
@@ -318,7 +318,7 @@ impl PerCpuModeEncodings {
 
 // Definitions.
 
-pub fn define(
+pub(crate) fn define(
     shared_defs: &SharedDefinitions,
     settings: &SettingGroup,
     x86: &InstructionGroup,

--- a/cranelift-codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift-codegen/meta/src/isa/x86/encodings.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use crate::cdsl::encodings::{Encoding, EncodingBuilder};
 use crate::cdsl::instructions::{
-    BoundInstruction, InstSpec, Instruction, InstructionGroup, InstructionPredicate,
+    Bindable, BoundInstruction, InstSpec, Instruction, InstructionGroup, InstructionPredicate,
     InstructionPredicateNode, InstructionPredicateRegistry,
 };
 use crate::cdsl::recipes::{EncodingRecipe, EncodingRecipeNumber, Recipes};

--- a/cranelift-codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift-codegen/meta/src/isa/x86/encodings.rs
@@ -372,6 +372,7 @@ pub(crate) fn define(
     let fpromote = shared.by_name("fpromote");
     let fsub = shared.by_name("fsub");
     let func_addr = shared.by_name("func_addr");
+    let get_pinned_reg = shared.by_name("get_pinned_reg");
     let iadd = shared.by_name("iadd");
     let iadd_cout = shared.by_name("iadd_cout");
     let iadd_cin = shared.by_name("iadd_cin");
@@ -421,6 +422,7 @@ pub(crate) fn define(
     let scalar_to_vector = shared.by_name("scalar_to_vector");
     let selectif = shared.by_name("selectif");
     let sextend = shared.by_name("sextend");
+    let set_pinned_reg = shared.by_name("set_pinned_reg");
     let sload16 = shared.by_name("sload16");
     let sload16_complex = shared.by_name("sload16_complex");
     let sload32 = shared.by_name("sload32");
@@ -516,6 +518,7 @@ pub(crate) fn define(
     let rec_furm = r.template("furm");
     let rec_furm_reg_to_ssa = r.template("furm_reg_to_ssa");
     let rec_furmi_rnd = r.template("furmi_rnd");
+    let rec_get_pinned_reg = r.recipe("get_pinned_reg");
     let rec_got_fnaddr8 = r.template("got_fnaddr8");
     let rec_got_gvaddr8 = r.template("got_gvaddr8");
     let rec_gvaddr4 = r.template("gvaddr4");
@@ -569,6 +572,7 @@ pub(crate) fn define(
     let rec_safepoint = r.recipe("safepoint");
     let rec_setf_abcd = r.template("setf_abcd");
     let rec_seti_abcd = r.template("seti_abcd");
+    let rec_set_pinned_reg = r.template("set_pinned_reg");
     let rec_spaddr4_id = r.template("spaddr4_id");
     let rec_spaddr8_id = r.template("spaddr8_id");
     let rec_spillSib32 = r.template("spillSib32");
@@ -618,6 +622,13 @@ pub(crate) fn define(
 
     // Definitions.
     let mut e = PerCpuModeEncodings::new();
+
+    // The pinned reg is fixed to a certain value entirely user-controlled, so it generates nothing!
+    e.enc64_rec(get_pinned_reg.bind(I64), rec_get_pinned_reg, 0);
+    e.enc_x86_64(
+        set_pinned_reg.bind(I64),
+        rec_set_pinned_reg.opcodes(vec![0x89]).rex().w(),
+    );
 
     e.enc_i32_i64(iadd, rec_rr.opcodes(vec![0x01]));
     e.enc_i32_i64(iadd_cout, rec_rr.opcodes(vec![0x01]));

--- a/cranelift-codegen/meta/src/isa/x86/encodings.rs
+++ b/cranelift-codegen/meta/src/isa/x86/encodings.rs
@@ -372,6 +372,9 @@ pub fn define(
     let fsub = shared.by_name("fsub");
     let func_addr = shared.by_name("func_addr");
     let iadd = shared.by_name("iadd");
+    let iadd_cout = shared.by_name("iadd_cout");
+    let iadd_cin = shared.by_name("iadd_cin");
+    let iadd_carry = shared.by_name("iadd_carry");
     let iadd_imm = shared.by_name("iadd_imm");
     let icmp = shared.by_name("icmp");
     let icmp_imm = shared.by_name("icmp_imm");
@@ -556,6 +559,8 @@ pub fn define(
     let rec_rfurm = r.template("rfurm");
     let rec_rmov = r.template("rmov");
     let rec_rr = r.template("rr");
+    let rec_rcin = r.template("rcin");
+    let rec_rcarry = r.template("rcarry");
     let rec_rrx = r.template("rrx");
     let rec_safepoint = r.recipe("safepoint");
     let rec_setf_abcd = r.template("setf_abcd");
@@ -611,6 +616,10 @@ pub fn define(
     let mut e = PerCpuModeEncodings::new();
 
     e.enc_i32_i64(iadd, rec_rr.opcodes(vec![0x01]));
+    e.enc_i32_i64(iadd_cout, rec_rr.opcodes(vec![0x01]));
+    e.enc_i32_i64(iadd_cin, rec_rcin.opcodes(vec![0x11]));
+    e.enc_i32_i64(iadd_carry, rec_rcarry.opcodes(vec![0x11]));
+
     e.enc_i32_i64(isub, rec_rr.opcodes(vec![0x29]));
     e.enc_i32_i64(band, rec_rr.opcodes(vec![0x21]));
     e.enc_i32_i64(bor, rec_rr.opcodes(vec![0x09]));

--- a/cranelift-codegen/meta/src/isa/x86/instructions.rs
+++ b/cranelift-codegen/meta/src/isa/x86/instructions.rs
@@ -10,7 +10,7 @@ use crate::cdsl::typevar::{Interval, TypeSetBuilder, TypeVar};
 use crate::shared::immediates::Immediates;
 use crate::shared::types;
 
-pub fn define(
+pub(crate) fn define(
     mut all_instructions: &mut AllInstructions,
     format_registry: &FormatRegistry,
     immediates: &Immediates,

--- a/cranelift-codegen/meta/src/isa/x86/instructions.rs
+++ b/cranelift-codegen/meta/src/isa/x86/instructions.rs
@@ -7,11 +7,13 @@ use crate::cdsl::instructions::{
 use crate::cdsl::operands::{create_operand as operand, create_operand_doc as operand_doc};
 use crate::cdsl::types::ValueType;
 use crate::cdsl::typevar::{Interval, TypeSetBuilder, TypeVar};
-use crate::shared::{immediates, types, OperandKinds};
+use crate::shared::immediates::Immediates;
+use crate::shared::types;
 
 pub fn define(
     mut all_instructions: &mut AllInstructions,
     format_registry: &FormatRegistry,
+    immediates: &Immediates,
 ) -> InstructionGroup {
     let mut ig = InstructionGroupBuilder::new(
         "x86",
@@ -249,8 +251,7 @@ pub fn define(
         .operands_out(vec![y, rflags]),
     );
 
-    let immediates = OperandKinds::from(immediates::define());
-    let uimm8 = immediates.by_name("uimm8");
+    let uimm8 = &immediates.uimm8;
     let TxN = &TypeVar::new(
         "TxN",
         "A SIMD vector type",

--- a/cranelift-codegen/meta/src/isa/x86/legalize.rs
+++ b/cranelift-codegen/meta/src/isa/x86/legalize.rs
@@ -58,12 +58,7 @@ pub fn define(shared: &mut SharedDefinitions, x86_instructions: &InstructionGrou
     let x86_umulx = x86_instructions.by_name("x86_umulx");
     let x86_smulx = x86_instructions.by_name("x86_smulx");
 
-    // List of immediates.
-    let floatcc = shared.operand_kinds.by_name("floatcc");
-    let imm64 = shared.operand_kinds.by_name("imm64");
-    let intcc = shared.operand_kinds.by_name("intcc");
-    let uimm8 = shared.operand_kinds.by_name("uimm8");
-    let ieee64 = shared.operand_kinds.by_name("ieee64");
+    let imm = &shared.imm;
 
     // Division and remainder.
     //
@@ -99,12 +94,12 @@ pub fn define(shared: &mut SharedDefinitions, x86_instructions: &InstructionGrou
     // `ucomiss` or `ucomisd` instruction. The remaining codes need legalization
     // patterns.
 
-    let floatcc_eq = Literal::enumerator_for(floatcc, "eq");
-    let floatcc_ord = Literal::enumerator_for(floatcc, "ord");
-    let floatcc_ueq = Literal::enumerator_for(floatcc, "ueq");
-    let floatcc_ne = Literal::enumerator_for(floatcc, "ne");
-    let floatcc_uno = Literal::enumerator_for(floatcc, "uno");
-    let floatcc_one = Literal::enumerator_for(floatcc, "one");
+    let floatcc_eq = Literal::enumerator_for(&imm.floatcc, "eq");
+    let floatcc_ord = Literal::enumerator_for(&imm.floatcc, "ord");
+    let floatcc_ueq = Literal::enumerator_for(&imm.floatcc, "ueq");
+    let floatcc_ne = Literal::enumerator_for(&imm.floatcc, "ne");
+    let floatcc_uno = Literal::enumerator_for(&imm.floatcc, "uno");
+    let floatcc_one = Literal::enumerator_for(&imm.floatcc, "one");
 
     // Equality needs an explicit `ord` test which checks the parity bit.
     group.legalize(
@@ -124,14 +119,14 @@ pub fn define(shared: &mut SharedDefinitions, x86_instructions: &InstructionGrou
         ],
     );
 
-    let floatcc_lt = &Literal::enumerator_for(floatcc, "lt");
-    let floatcc_gt = &Literal::enumerator_for(floatcc, "gt");
-    let floatcc_le = &Literal::enumerator_for(floatcc, "le");
-    let floatcc_ge = &Literal::enumerator_for(floatcc, "ge");
-    let floatcc_ugt = &Literal::enumerator_for(floatcc, "ugt");
-    let floatcc_ult = &Literal::enumerator_for(floatcc, "ult");
-    let floatcc_uge = &Literal::enumerator_for(floatcc, "uge");
-    let floatcc_ule = &Literal::enumerator_for(floatcc, "ule");
+    let floatcc_lt = &Literal::enumerator_for(&imm.floatcc, "lt");
+    let floatcc_gt = &Literal::enumerator_for(&imm.floatcc, "gt");
+    let floatcc_le = &Literal::enumerator_for(&imm.floatcc, "le");
+    let floatcc_ge = &Literal::enumerator_for(&imm.floatcc, "ge");
+    let floatcc_ugt = &Literal::enumerator_for(&imm.floatcc, "ugt");
+    let floatcc_ult = &Literal::enumerator_for(&imm.floatcc, "ult");
+    let floatcc_uge = &Literal::enumerator_for(&imm.floatcc, "uge");
+    let floatcc_ule = &Literal::enumerator_for(&imm.floatcc, "ule");
 
     // Inequalities that need to be reversed.
     for &(cc, rev_cc) in &[
@@ -165,9 +160,9 @@ pub fn define(shared: &mut SharedDefinitions, x86_instructions: &InstructionGrou
     let r2flags = var("r2flags");
     let index2 = var("index2");
 
-    let intcc_eq = Literal::enumerator_for(intcc, "eq");
-    let imm64_minus_one = Literal::constant(imm64, -1);
-    let imm64_63 = Literal::constant(imm64, 63);
+    let intcc_eq = Literal::enumerator_for(&imm.intcc, "eq");
+    let imm64_minus_one = Literal::constant(&imm.imm64, -1);
+    let imm64_63 = Literal::constant(&imm.imm64, 63);
     group.legalize(
         def!(a = clz.I64(x)),
         vec![
@@ -179,7 +174,7 @@ pub fn define(shared: &mut SharedDefinitions, x86_instructions: &InstructionGrou
         ],
     );
 
-    let imm64_31 = Literal::constant(imm64, 31);
+    let imm64_31 = Literal::constant(&imm.imm64, 31);
     group.legalize(
         def!(a = clz.I32(x)),
         vec![
@@ -191,7 +186,7 @@ pub fn define(shared: &mut SharedDefinitions, x86_instructions: &InstructionGrou
         ],
     );
 
-    let imm64_64 = Literal::constant(imm64, 64);
+    let imm64_64 = Literal::constant(&imm.imm64, 64);
     group.legalize(
         def!(a = ctz.I64(x)),
         vec![
@@ -201,7 +196,7 @@ pub fn define(shared: &mut SharedDefinitions, x86_instructions: &InstructionGrou
         ],
     );
 
-    let imm64_32 = Literal::constant(imm64, 32);
+    let imm64_32 = Literal::constant(&imm.imm64, 32);
     group.legalize(
         def!(a = ctz.I32(x)),
         vec![
@@ -232,13 +227,13 @@ pub fn define(shared: &mut SharedDefinitions, x86_instructions: &InstructionGrou
     let qc0F = var("qc0F");
     let qc01 = var("qc01");
 
-    let imm64_1 = Literal::constant(imm64, 1);
-    let imm64_4 = Literal::constant(imm64, 4);
+    let imm64_1 = Literal::constant(&imm.imm64, 1);
+    let imm64_4 = Literal::constant(&imm.imm64, 4);
     group.legalize(
         def!(qv16 = popcnt.I64(qv1)),
         vec![
             def!(qv3 = ushr_imm(qv1, imm64_1)),
-            def!(qc77 = iconst(Literal::constant(imm64, 0x7777777777777777))),
+            def!(qc77 = iconst(Literal::constant(&imm.imm64, 0x7777777777777777))),
             def!(qv4 = band(qv3, qc77)),
             def!(qv5 = isub(qv1, qv4)),
             def!(qv6 = ushr_imm(qv4, imm64_1)),
@@ -249,11 +244,11 @@ pub fn define(shared: &mut SharedDefinitions, x86_instructions: &InstructionGrou
             def!(qv11 = isub(qv8, qv10)),
             def!(qv12 = ushr_imm(qv11, imm64_4)),
             def!(qv13 = iadd(qv11, qv12)),
-            def!(qc0F = iconst(Literal::constant(imm64, 0x0F0F0F0F0F0F0F0F))),
+            def!(qc0F = iconst(Literal::constant(&imm.imm64, 0x0F0F0F0F0F0F0F0F))),
             def!(qv14 = band(qv13, qc0F)),
-            def!(qc01 = iconst(Literal::constant(imm64, 0x0101010101010101))),
+            def!(qc01 = iconst(Literal::constant(&imm.imm64, 0x0101010101010101))),
             def!(qv15 = imul(qv14, qc01)),
-            def!(qv16 = ushr_imm(qv15, Literal::constant(imm64, 56))),
+            def!(qv16 = ushr_imm(qv15, Literal::constant(&imm.imm64, 56))),
         ],
     );
 
@@ -281,7 +276,7 @@ pub fn define(shared: &mut SharedDefinitions, x86_instructions: &InstructionGrou
         def!(lv16 = popcnt.I32(lv1)),
         vec![
             def!(lv3 = ushr_imm(lv1, imm64_1)),
-            def!(lc77 = iconst(Literal::constant(imm64, 0x77777777))),
+            def!(lc77 = iconst(Literal::constant(&imm.imm64, 0x77777777))),
             def!(lv4 = band(lv3, lc77)),
             def!(lv5 = isub(lv1, lv4)),
             def!(lv6 = ushr_imm(lv4, imm64_1)),
@@ -292,11 +287,11 @@ pub fn define(shared: &mut SharedDefinitions, x86_instructions: &InstructionGrou
             def!(lv11 = isub(lv8, lv10)),
             def!(lv12 = ushr_imm(lv11, imm64_4)),
             def!(lv13 = iadd(lv11, lv12)),
-            def!(lc0F = iconst(Literal::constant(imm64, 0x0F0F0F0F))),
+            def!(lc0F = iconst(Literal::constant(&imm.imm64, 0x0F0F0F0F))),
             def!(lv14 = band(lv13, lc0F)),
-            def!(lc01 = iconst(Literal::constant(imm64, 0x01010101))),
+            def!(lc01 = iconst(Literal::constant(&imm.imm64, 0x01010101))),
             def!(lv15 = imul(lv14, lc01)),
-            def!(lv16 = ushr_imm(lv15, Literal::constant(imm64, 24))),
+            def!(lv16 = ushr_imm(lv15, Literal::constant(&imm.imm64, 24))),
         ],
     );
 
@@ -313,9 +308,9 @@ pub fn define(shared: &mut SharedDefinitions, x86_instructions: &InstructionGrou
     .chain_with(shared.transform_groups.by_name("narrow").id);
 
     // SIMD
-    let uimm8_zero = Literal::constant(uimm8, 0x00);
-    let uimm8_one = Literal::constant(uimm8, 0x01);
-    let ieee64_zero = Literal::constant(ieee64, 0x00);
+    let uimm8_zero = Literal::constant(&imm.uimm8, 0x00);
+    let uimm8_one = Literal::constant(&imm.uimm8, 0x01);
+    let ieee64_zero = Literal::constant(&imm.ieee64, 0x00);
     let b = var("b");
     let c = var("c");
     let d = var("d");

--- a/cranelift-codegen/meta/src/isa/x86/legalize.rs
+++ b/cranelift-codegen/meta/src/isa/x86/legalize.rs
@@ -6,7 +6,7 @@ use crate::shared::types::Float::F64;
 use crate::shared::types::Int::{I32, I64};
 use crate::shared::Definitions as SharedDefinitions;
 
-pub fn define(shared: &mut SharedDefinitions, x86_instructions: &InstructionGroup) {
+pub(crate) fn define(shared: &mut SharedDefinitions, x86_instructions: &InstructionGroup) {
     let mut group = TransformGroupBuilder::new(
         "x86_expand",
         r#"

--- a/cranelift-codegen/meta/src/isa/x86/legalize.rs
+++ b/cranelift-codegen/meta/src/isa/x86/legalize.rs
@@ -1,5 +1,5 @@
 use crate::cdsl::ast::{var, ExprBuilder, Literal};
-use crate::cdsl::instructions::InstructionGroup;
+use crate::cdsl::instructions::{Bindable, InstructionGroup};
 use crate::cdsl::types::ValueType;
 use crate::cdsl::xform::TransformGroupBuilder;
 use crate::shared::types::Float::F64;

--- a/cranelift-codegen/meta/src/isa/x86/legalize.rs
+++ b/cranelift-codegen/meta/src/isa/x86/legalize.rs
@@ -320,8 +320,8 @@ pub(crate) fn define(shared: &mut SharedDefinitions, x86_instructions: &Instruct
 
     // SIMD splat: 8-bits
     for ty in ValueType::all_lane_types().filter(|t| t.lane_bits() == 8) {
-        let splat_any8x16 = splat.bind_vector_from_lane(ty, sse_vector_size);
-        let bitcast_f64_to_any8x16 = bitcast.bind_vector_from_lane(ty, sse_vector_size).bind(F64);
+        let splat_any8x16 = splat.bind_vector(ty, sse_vector_size);
+        let bitcast_f64_to_any8x16 = bitcast.bind_vector(ty, sse_vector_size).bind(F64);
         narrow.legalize(
             def!(y = splat_any8x16(x)),
             vec![
@@ -335,13 +335,13 @@ pub(crate) fn define(shared: &mut SharedDefinitions, x86_instructions: &Instruct
 
     // SIMD splat: 16-bits
     for ty in ValueType::all_lane_types().filter(|t| t.lane_bits() == 16) {
-        let splat_x16x8 = splat.bind_vector_from_lane(ty, sse_vector_size);
+        let splat_x16x8 = splat.bind_vector(ty, sse_vector_size);
         let raw_bitcast_any16x8_to_i32x4 = raw_bitcast
-            .bind_vector_from_lane(I32, sse_vector_size)
-            .bind_vector_from_lane(ty, sse_vector_size);
+            .bind_vector(I32, sse_vector_size)
+            .bind_vector(ty, sse_vector_size);
         let raw_bitcast_i32x4_to_any16x8 = raw_bitcast
-            .bind_vector_from_lane(ty, sse_vector_size)
-            .bind_vector_from_lane(I32, sse_vector_size);
+            .bind_vector(ty, sse_vector_size)
+            .bind_vector(I32, sse_vector_size);
         narrow.legalize(
             def!(y = splat_x16x8(x)),
             vec![
@@ -356,7 +356,7 @@ pub(crate) fn define(shared: &mut SharedDefinitions, x86_instructions: &Instruct
 
     // SIMD splat: 32-bits
     for ty in ValueType::all_lane_types().filter(|t| t.lane_bits() == 32) {
-        let splat_any32x4 = splat.bind_vector_from_lane(ty, sse_vector_size);
+        let splat_any32x4 = splat.bind_vector(ty, sse_vector_size);
         narrow.legalize(
             def!(y = splat_any32x4(x)),
             vec![
@@ -368,7 +368,7 @@ pub(crate) fn define(shared: &mut SharedDefinitions, x86_instructions: &Instruct
 
     // SIMD splat: 64-bits
     for ty in ValueType::all_lane_types().filter(|t| t.lane_bits() == 64) {
-        let splat_any64x2 = splat.bind_vector_from_lane(ty, sse_vector_size);
+        let splat_any64x2 = splat.bind_vector(ty, sse_vector_size);
         narrow.legalize(
             def!(y = splat_any64x2(x)),
             vec![

--- a/cranelift-codegen/meta/src/isa/x86/mod.rs
+++ b/cranelift-codegen/meta/src/isa/x86/mod.rs
@@ -13,7 +13,7 @@ mod recipes;
 mod registers;
 mod settings;
 
-pub fn define(shared_defs: &mut SharedDefinitions) -> TargetIsa {
+pub(crate) fn define(shared_defs: &mut SharedDefinitions) -> TargetIsa {
     let settings = settings::define(&shared_defs.settings);
     let regs = registers::define();
 

--- a/cranelift-codegen/meta/src/isa/x86/mod.rs
+++ b/cranelift-codegen/meta/src/isa/x86/mod.rs
@@ -20,6 +20,7 @@ pub fn define(shared_defs: &mut SharedDefinitions) -> TargetIsa {
     let inst_group = instructions::define(
         &mut shared_defs.all_instructions,
         &shared_defs.format_registry,
+        &shared_defs.imm,
     );
     legalize::define(shared_defs, &inst_group);
 

--- a/cranelift-codegen/meta/src/isa/x86/recipes.rs
+++ b/cranelift-codegen/meta/src/isa/x86/recipes.rs
@@ -332,7 +332,7 @@ pub fn define<'shared>(
 ) -> RecipeGroup<'shared> {
     // The set of floating point condition codes that are directly supported.
     // Other condition codes need to be reversed or expressed as two tests.
-    let floatcc = shared_defs.operand_kinds.by_name("floatcc");
+    let floatcc = &shared_defs.imm.floatcc;
     let supported_floatccs: Vec<Literal> = ["ord", "uno", "one", "ueq", "gt", "ge", "ult", "ule"]
         .iter()
         .map(|name| Literal::enumerator_for(floatcc, name))

--- a/cranelift-codegen/meta/src/isa/x86/recipes.rs
+++ b/cranelift-codegen/meta/src/isa/x86/recipes.rs
@@ -2532,7 +2532,7 @@ pub fn define<'shared>(
 
     // XX /r, MR form. Add two GPR registers and get carry flag.
     recipes.add_template_recipe(
-        EncodingRecipeBuilder::new("rcin", f_ternary, 1)
+        EncodingRecipeBuilder::new("rin", f_ternary, 1)
             .operands_in(vec![
                 OperandConstraint::RegClass(gpr),
                 OperandConstraint::RegClass(gpr),
@@ -2550,7 +2550,7 @@ pub fn define<'shared>(
 
     // XX /r, MR form. Add two GPR registers with carry flag.
     recipes.add_template_recipe(
-        EncodingRecipeBuilder::new("rcarry", f_ternary, 1)
+        EncodingRecipeBuilder::new("rio", f_ternary, 1)
             .operands_in(vec![
                 OperandConstraint::RegClass(gpr),
                 OperandConstraint::RegClass(gpr),

--- a/cranelift-codegen/meta/src/isa/x86/recipes.rs
+++ b/cranelift-codegen/meta/src/isa/x86/recipes.rs
@@ -325,7 +325,7 @@ fn valid_scale(format: &InstructionFormat) -> InstructionPredicate {
         })
 }
 
-pub fn define<'shared>(
+pub(crate) fn define<'shared>(
     shared_defs: &'shared SharedDefinitions,
     settings: &'shared SettingGroup,
     regs: &'shared IsaRegs,

--- a/cranelift-codegen/meta/src/isa/x86/recipes.rs
+++ b/cranelift-codegen/meta/src/isa/x86/recipes.rs
@@ -2528,6 +2528,47 @@ pub fn define<'shared>(
             ),
     );
 
+    // Adding with carry
+
+    // XX /r, MR form. Add two GPR registers and get carry flag.
+    recipes.add_template_recipe(
+        EncodingRecipeBuilder::new("rcin", f_ternary, 1)
+            .operands_in(vec![
+                OperandConstraint::RegClass(gpr),
+                OperandConstraint::RegClass(gpr),
+                OperandConstraint::FixedReg(reg_rflags),
+            ])
+            .operands_out(vec![0])
+            .clobbers_flags(true)
+            .emit(
+                r#"
+                    {{PUT_OP}}(bits, rex2(in_reg0, in_reg1), sink);
+                    modrm_rr(in_reg0, in_reg1, sink);
+                "#,
+            ),
+    );
+
+    // XX /r, MR form. Add two GPR registers with carry flag.
+    recipes.add_template_recipe(
+        EncodingRecipeBuilder::new("rcarry", f_ternary, 1)
+            .operands_in(vec![
+                OperandConstraint::RegClass(gpr),
+                OperandConstraint::RegClass(gpr),
+                OperandConstraint::FixedReg(reg_rflags),
+            ])
+            .operands_out(vec![
+                OperandConstraint::TiedInput(0),
+                OperandConstraint::FixedReg(reg_rflags),
+            ])
+            .clobbers_flags(true)
+            .emit(
+                r#"
+                    {{PUT_OP}}(bits, rex2(in_reg0, in_reg1), sink);
+                    modrm_rr(in_reg0, in_reg1, sink);
+                "#,
+            ),
+    );
+
     // Compare and set flags.
 
     // XX /r, MR form. Compare two GPR registers and set flags.

--- a/cranelift-codegen/meta/src/isa/x86/registers.rs
+++ b/cranelift-codegen/meta/src/isa/x86/registers.rs
@@ -6,7 +6,8 @@ pub fn define() -> IsaRegs {
     let builder = RegBankBuilder::new("IntRegs", "r")
         .units(16)
         .names(vec!["rax", "rcx", "rdx", "rbx", "rsp", "rbp", "rsi", "rdi"])
-        .track_pressure(true);
+        .track_pressure(true)
+        .pinned_reg(15);
     let int_regs = regs.add_bank(builder);
 
     let builder = RegBankBuilder::new("FloatRegs", "xmm")

--- a/cranelift-codegen/meta/src/shared/entities.rs
+++ b/cranelift-codegen/meta/src/shared/entities.rs
@@ -1,65 +1,76 @@
 use crate::cdsl::operands::{OperandKind, OperandKindBuilder as Builder, OperandKindFields};
 
+pub struct EntityRefs {
+    /// A reference to an extended basic block in the same function.
+    /// This is primarliy used in control flow instructions.
+    pub ebb: OperandKind,
+
+    /// A reference to a stack slot declared in the function preamble.
+    pub stack_slot: OperandKind,
+
+    /// A reference to a global value.
+    pub global_value: OperandKind,
+
+    /// A reference to a function signature declared in the function preamble.
+    /// This is used to provide the call signature in a call_indirect instruction.
+    pub sig_ref: OperandKind,
+
+    /// A reference to an external function declared in the function preamble.
+    /// This is used to provide the callee and signature in a call instruction.
+    pub func_ref: OperandKind,
+
+    /// A reference to a jump table declared in the function preamble.
+    pub jump_table: OperandKind,
+
+    /// A reference to a heap declared in the function preamble.
+    pub heap: OperandKind,
+
+    /// A reference to a table declared in the function preamble.
+    pub table: OperandKind,
+
+    /// A variable-sized list of value operands. Use for Ebb and function call arguments.
+    pub varargs: OperandKind,
+}
+
+impl EntityRefs {
+    pub fn new() -> Self {
+        Self {
+            ebb: create("ebb", "An extended basic block in the same function.")
+                .default_member("destination")
+                .build(),
+
+            stack_slot: create("stack_slot", "A stack slot").build(),
+
+            global_value: create("global_value", "A global value.").build(),
+
+            sig_ref: create("sig_ref", "A function signature.").build(),
+
+            func_ref: create("func_ref", "An external function.").build(),
+
+            jump_table: create("jump_table", "A jump table.")
+                .default_member("table")
+                .build(),
+
+            heap: create("heap", "A heap.").build(),
+
+            table: create("table", "A table.").build(),
+
+            varargs: Builder::new("variable_args", OperandKindFields::VariableArgs)
+                .doc(
+                    r#"
+                        A variable size list of `value` operands.
+
+                        Use this to represent arguments passed to a function call, arguments
+                        passed to an extended basic block, or a variable number of results
+                        returned from an instruction.
+                    "#,
+                )
+                .build(),
+        }
+    }
+}
+
 /// Small helper to initialize an OperandBuilder with the right kind, for a given name and doc.
 fn create(name: &'static str, doc: &'static str) -> Builder {
     Builder::new(name, OperandKindFields::EntityRef).doc(doc)
-}
-
-pub fn define() -> Vec<OperandKind> {
-    let mut kinds = Vec::new();
-
-    // A reference to an extended basic block in the same function.
-    // This is primarliy used in control flow instructions.
-    let ebb = create("ebb", "An extended basic block in the same function.")
-        .default_member("destination")
-        .build();
-    kinds.push(ebb);
-
-    // A reference to a stack slot declared in the function preamble.
-    let stack_slot = create("stack_slot", "A stack slot").build();
-    kinds.push(stack_slot);
-
-    // A reference to a global value.
-    let global_value = create("global_value", "A global value.").build();
-    kinds.push(global_value);
-
-    // A reference to a function signature declared in the function preamble.
-    // This is used to provide the call signature in a call_indirect instruction.
-    let sig_ref = create("sig_ref", "A function signature.").build();
-    kinds.push(sig_ref);
-
-    // A reference to an external function declared in the function preamble.
-    // This is used to provide the callee and signature in a call instruction.
-    let func_ref = create("func_ref", "An external function.").build();
-    kinds.push(func_ref);
-
-    // A reference to a jump table declared in the function preamble.
-    let jump_table = create("jump_table", "A jump table.")
-        .default_member("table")
-        .build();
-    kinds.push(jump_table);
-
-    // A reference to a heap declared in the function preamble.
-    let heap = create("heap", "A heap.").build();
-    kinds.push(heap);
-
-    // A reference to a table declared in the function preamble.
-    let table = create("table", "A table.").build();
-    kinds.push(table);
-
-    // A variable-sized list of value operands. Use for Ebb and function call arguments.
-    let varargs = Builder::new("variable_args", OperandKindFields::VariableArgs)
-        .doc(
-            r#"
-            A variable size list of `value` operands.
-
-            Use this to represent arguments passed to a function call, arguments
-            passed to an extended basic block, or a variable number of results
-            returned from an instruction.
-        "#,
-        )
-        .build();
-    kinds.push(varargs);
-
-    return kinds;
 }

--- a/cranelift-codegen/meta/src/shared/formats.rs
+++ b/cranelift-codegen/meta/src/shared/formats.rs
@@ -1,7 +1,7 @@
 use crate::cdsl::formats::{FormatRegistry, InstructionFormatBuilder as Builder};
 use crate::shared::{entities::EntityRefs, immediates::Immediates};
 
-pub fn define(imm: &Immediates, entities: &EntityRefs) -> FormatRegistry {
+pub(crate) fn define(imm: &Immediates, entities: &EntityRefs) -> FormatRegistry {
     let mut registry = FormatRegistry::new();
 
     registry.insert(Builder::new("Unary").value());

--- a/cranelift-codegen/meta/src/shared/formats.rs
+++ b/cranelift-codegen/meta/src/shared/formats.rs
@@ -60,10 +60,14 @@ pub fn define(immediates: &OperandKinds, entities: &OperandKinds) -> FormatRegis
     registry.insert(
         Builder::new("InsertLane")
             .value()
-            .imm(("lane", uimm8))
+            .imm_with_name("lane", uimm8)
             .value(),
     );
-    registry.insert(Builder::new("ExtractLane").value().imm(("lane", uimm8)));
+    registry.insert(
+        Builder::new("ExtractLane")
+            .value()
+            .imm_with_name("lane", uimm8),
+    );
 
     registry.insert(Builder::new("IntCompare").imm(intcc).value().value());
     registry.insert(Builder::new("IntCompareImm").imm(intcc).value().imm(imm64));
@@ -151,26 +155,26 @@ pub fn define(immediates: &OperandKinds, entities: &OperandKinds) -> FormatRegis
     registry.insert(
         Builder::new("RegMove")
             .value()
-            .imm(("src", regunit))
-            .imm(("dst", regunit)),
+            .imm_with_name("src", regunit)
+            .imm_with_name("dst", regunit),
     );
     registry.insert(
         Builder::new("CopySpecial")
-            .imm(("src", regunit))
-            .imm(("dst", regunit)),
+            .imm_with_name("src", regunit)
+            .imm_with_name("dst", regunit),
     );
-    registry.insert(Builder::new("CopyToSsa").imm(("src", regunit)));
+    registry.insert(Builder::new("CopyToSsa").imm_with_name("src", regunit));
     registry.insert(
         Builder::new("RegSpill")
             .value()
-            .imm(("src", regunit))
-            .imm(("dst", stack_slot)),
+            .imm_with_name("src", regunit)
+            .imm_with_name("dst", stack_slot),
     );
     registry.insert(
         Builder::new("RegFill")
             .value()
-            .imm(("src", stack_slot))
-            .imm(("dst", regunit)),
+            .imm_with_name("src", stack_slot)
+            .imm_with_name("dst", regunit),
     );
 
     registry.insert(Builder::new("Trap").imm(trapcode));

--- a/cranelift-codegen/meta/src/shared/formats.rs
+++ b/cranelift-codegen/meta/src/shared/formats.rs
@@ -1,22 +1,8 @@
 use crate::cdsl::formats::{FormatRegistry, InstructionFormatBuilder as Builder};
+use crate::shared::immediates::Immediates;
 use crate::shared::OperandKinds;
 
-pub fn define(immediates: &OperandKinds, entities: &OperandKinds) -> FormatRegistry {
-    // Shorthands for immediates.
-    let uimm8 = immediates.by_name("uimm8");
-    let uimm32 = immediates.by_name("uimm32");
-    let uimm128 = immediates.by_name("uimm128");
-    let imm64 = immediates.by_name("imm64");
-    let ieee32 = immediates.by_name("ieee32");
-    let ieee64 = immediates.by_name("ieee64");
-    let boolean = immediates.by_name("boolean");
-    let intcc = immediates.by_name("intcc");
-    let floatcc = immediates.by_name("floatcc");
-    let memflags = immediates.by_name("memflags");
-    let offset32 = immediates.by_name("offset32");
-    let trapcode = immediates.by_name("trapcode");
-    let regunit = immediates.by_name("regunit");
-
+pub fn define(imm: &Immediates, entities: &OperandKinds) -> FormatRegistry {
     // Shorthands for entities.
     let global_value = entities.by_name("global_value");
     let ebb = entities.by_name("ebb");
@@ -30,15 +16,15 @@ pub fn define(immediates: &OperandKinds, entities: &OperandKinds) -> FormatRegis
     let mut registry = FormatRegistry::new();
 
     registry.insert(Builder::new("Unary").value());
-    registry.insert(Builder::new("UnaryImm").imm(imm64));
-    registry.insert(Builder::new("UnaryImm128").imm(uimm128));
-    registry.insert(Builder::new("UnaryIeee32").imm(ieee32));
-    registry.insert(Builder::new("UnaryIeee64").imm(ieee64));
-    registry.insert(Builder::new("UnaryBool").imm(boolean));
+    registry.insert(Builder::new("UnaryImm").imm(&imm.imm64));
+    registry.insert(Builder::new("UnaryImm128").imm(&imm.uimm128));
+    registry.insert(Builder::new("UnaryIeee32").imm(&imm.ieee32));
+    registry.insert(Builder::new("UnaryIeee64").imm(&imm.ieee64));
+    registry.insert(Builder::new("UnaryBool").imm(&imm.boolean));
     registry.insert(Builder::new("UnaryGlobalValue").imm(global_value));
 
     registry.insert(Builder::new("Binary").value().value());
-    registry.insert(Builder::new("BinaryImm").value().imm(imm64));
+    registry.insert(Builder::new("BinaryImm").value().imm(&imm.imm64));
 
     // The select instructions are controlled by the second VALUE operand.
     // The first VALUE operand is the controlling flag which has a derived type.
@@ -60,43 +46,59 @@ pub fn define(immediates: &OperandKinds, entities: &OperandKinds) -> FormatRegis
     registry.insert(
         Builder::new("InsertLane")
             .value()
-            .imm_with_name("lane", uimm8)
+            .imm_with_name("lane", &imm.uimm8)
             .value(),
     );
     registry.insert(
         Builder::new("ExtractLane")
             .value()
-            .imm_with_name("lane", uimm8),
+            .imm_with_name("lane", &imm.uimm8),
     );
 
-    registry.insert(Builder::new("IntCompare").imm(intcc).value().value());
-    registry.insert(Builder::new("IntCompareImm").imm(intcc).value().imm(imm64));
-    registry.insert(Builder::new("IntCond").imm(intcc).value());
+    registry.insert(Builder::new("IntCompare").imm(&imm.intcc).value().value());
+    registry.insert(
+        Builder::new("IntCompareImm")
+            .imm(&imm.intcc)
+            .value()
+            .imm(&imm.imm64),
+    );
+    registry.insert(Builder::new("IntCond").imm(&imm.intcc).value());
 
-    registry.insert(Builder::new("FloatCompare").imm(floatcc).value().value());
-    registry.insert(Builder::new("FloatCond").imm(floatcc).value());;
+    registry.insert(
+        Builder::new("FloatCompare")
+            .imm(&imm.floatcc)
+            .value()
+            .value(),
+    );
+    registry.insert(Builder::new("FloatCond").imm(&imm.floatcc).value());;
 
-    registry.insert(Builder::new("IntSelect").imm(intcc).value().value().value());
+    registry.insert(
+        Builder::new("IntSelect")
+            .imm(&imm.intcc)
+            .value()
+            .value()
+            .value(),
+    );
 
     registry.insert(Builder::new("Jump").imm(ebb).varargs());
     registry.insert(Builder::new("Branch").value().imm(ebb).varargs());
     registry.insert(
         Builder::new("BranchInt")
-            .imm(intcc)
+            .imm(&imm.intcc)
             .value()
             .imm(ebb)
             .varargs(),
     );
     registry.insert(
         Builder::new("BranchFloat")
-            .imm(floatcc)
+            .imm(&imm.floatcc)
             .value()
             .imm(ebb)
             .varargs(),
     );
     registry.insert(
         Builder::new("BranchIcmp")
-            .imm(intcc)
+            .imm(&imm.intcc)
             .value()
             .value()
             .imm(ebb)
@@ -107,7 +109,7 @@ pub fn define(immediates: &OperandKinds, entities: &OperandKinds) -> FormatRegis
         Builder::new("BranchTableEntry")
             .value()
             .value()
-            .imm(uimm8)
+            .imm(&imm.uimm8)
             .imm(jump_table),
     );
     registry.insert(Builder::new("BranchTableBase").imm(jump_table));
@@ -117,74 +119,89 @@ pub fn define(immediates: &OperandKinds, entities: &OperandKinds) -> FormatRegis
     registry.insert(Builder::new("CallIndirect").imm(sig_ref).value().varargs());
     registry.insert(Builder::new("FuncAddr").imm(func_ref));
 
-    registry.insert(Builder::new("Load").imm(memflags).value().imm(offset32));
+    registry.insert(
+        Builder::new("Load")
+            .imm(&imm.memflags)
+            .value()
+            .imm(&imm.offset32),
+    );
     registry.insert(
         Builder::new("LoadComplex")
-            .imm(memflags)
+            .imm(&imm.memflags)
             .varargs()
-            .imm(offset32),
+            .imm(&imm.offset32),
     );
     registry.insert(
         Builder::new("Store")
-            .imm(memflags)
+            .imm(&imm.memflags)
             .value()
             .value()
-            .imm(offset32),
+            .imm(&imm.offset32),
     );
     registry.insert(
         Builder::new("StoreComplex")
-            .imm(memflags)
+            .imm(&imm.memflags)
             .value()
             .varargs()
-            .imm(offset32),
+            .imm(&imm.offset32),
     );
-    registry.insert(Builder::new("StackLoad").imm(stack_slot).imm(offset32));
+    registry.insert(Builder::new("StackLoad").imm(stack_slot).imm(&imm.offset32));
     registry.insert(
         Builder::new("StackStore")
             .value()
             .imm(stack_slot)
-            .imm(offset32),
+            .imm(&imm.offset32),
     );
 
     // Accessing a WebAssembly heap.
-    registry.insert(Builder::new("HeapAddr").imm(heap).value().imm(uimm32));
+    registry.insert(Builder::new("HeapAddr").imm(heap).value().imm(&imm.uimm32));
 
     // Accessing a WebAssembly table.
-    registry.insert(Builder::new("TableAddr").imm(table).value().imm(offset32));
+    registry.insert(
+        Builder::new("TableAddr")
+            .imm(table)
+            .value()
+            .imm(&imm.offset32),
+    );
 
     registry.insert(
         Builder::new("RegMove")
             .value()
-            .imm_with_name("src", regunit)
-            .imm_with_name("dst", regunit),
+            .imm_with_name("src", &imm.regunit)
+            .imm_with_name("dst", &imm.regunit),
     );
     registry.insert(
         Builder::new("CopySpecial")
-            .imm_with_name("src", regunit)
-            .imm_with_name("dst", regunit),
+            .imm_with_name("src", &imm.regunit)
+            .imm_with_name("dst", &imm.regunit),
     );
-    registry.insert(Builder::new("CopyToSsa").imm_with_name("src", regunit));
+    registry.insert(Builder::new("CopyToSsa").imm_with_name("src", &imm.regunit));
     registry.insert(
         Builder::new("RegSpill")
             .value()
-            .imm_with_name("src", regunit)
+            .imm_with_name("src", &imm.regunit)
             .imm_with_name("dst", stack_slot),
     );
     registry.insert(
         Builder::new("RegFill")
             .value()
             .imm_with_name("src", stack_slot)
-            .imm_with_name("dst", regunit),
+            .imm_with_name("dst", &imm.regunit),
     );
 
-    registry.insert(Builder::new("Trap").imm(trapcode));
-    registry.insert(Builder::new("CondTrap").value().imm(trapcode));
-    registry.insert(Builder::new("IntCondTrap").imm(intcc).value().imm(trapcode));
+    registry.insert(Builder::new("Trap").imm(&imm.trapcode));
+    registry.insert(Builder::new("CondTrap").value().imm(&imm.trapcode));
+    registry.insert(
+        Builder::new("IntCondTrap")
+            .imm(&imm.intcc)
+            .value()
+            .imm(&imm.trapcode),
+    );
     registry.insert(
         Builder::new("FloatCondTrap")
-            .imm(floatcc)
+            .imm(&imm.floatcc)
             .value()
-            .imm(trapcode),
+            .imm(&imm.trapcode),
     );
 
     registry

--- a/cranelift-codegen/meta/src/shared/immediates.rs
+++ b/cranelift-codegen/meta/src/shared/immediates.rs
@@ -2,7 +2,7 @@ use crate::cdsl::operands::{OperandKind, OperandKindBuilder as Builder};
 
 use std::collections::HashMap;
 
-pub struct Immediates {
+pub(crate) struct Immediates {
     /// A 64-bit immediate integer operand.
     ///
     /// This type of immediate integer can interact with SSA values with any IntType type.

--- a/cranelift-codegen/meta/src/shared/immediates.rs
+++ b/cranelift-codegen/meta/src/shared/immediates.rs
@@ -2,154 +2,174 @@ use crate::cdsl::operands::{OperandKind, OperandKindBuilder as Builder};
 
 use std::collections::HashMap;
 
-pub fn define() -> Vec<OperandKind> {
-    let mut kinds = Vec::new();
+pub struct Immediates {
+    /// A 64-bit immediate integer operand.
+    ///
+    /// This type of immediate integer can interact with SSA values with any IntType type.
+    pub imm64: OperandKind,
 
-    // A 64-bit immediate integer operand.
-    //
-    // This type of immediate integer can interact with SSA values with any
-    // IntType type.
-    let imm64 = Builder::new_imm("imm64")
-        .doc("A 64-bit immediate integer.")
-        .build();
-    kinds.push(imm64);
+    /// An unsigned 8-bit immediate integer operand.
+    ///
+    /// This small operand is used to indicate lane indexes in SIMD vectors and immediate bit
+    /// counts on shift instructions.
+    pub uimm8: OperandKind,
 
-    // An unsigned 8-bit immediate integer operand.
-    //
-    // This small operand is used to indicate lane indexes in SIMD vectors and
-    // immediate bit counts on shift instructions.
-    let uimm8 = Builder::new_imm("uimm8")
-        .doc("An 8-bit immediate unsigned integer.")
-        .build();
-    kinds.push(uimm8);
+    /// An unsigned 32-bit immediate integer operand.
+    pub uimm32: OperandKind,
 
-    // An unsigned 32-bit immediate integer operand.
-    let uimm32 = Builder::new_imm("uimm32")
-        .doc("A 32-bit immediate unsigned integer.")
-        .build();
-    kinds.push(uimm32);
+    /// An unsigned 128-bit immediate integer operand.
+    ///
+    /// This operand is used to pass entire 128-bit vectors as immediates to instructions like
+    /// const.
+    pub uimm128: OperandKind,
 
-    // An unsigned 128-bit immediate integer operand.
-    //
-    // This operand is used to pass entire 128-bit vectors as immediates to
-    // instructions like const.
-    let uimm128 = Builder::new_imm("uimm128")
-        .doc("A 128-bit immediate unsigned integer.")
-        .rust_type("ir::Constant")
-        .build();
-    kinds.push(uimm128);
+    /// A 32-bit immediate signed offset.
+    ///
+    /// This is used to represent an immediate address offset in load/store instructions.
+    pub offset32: OperandKind,
 
-    // A 32-bit immediate signed offset.
-    //
-    // This is used to represent an immediate address offset in load/store
-    // instructions.
-    let offset32 = Builder::new_imm("offset32")
-        .doc("A 32-bit immediate signed offset.")
-        .default_member("offset")
-        .build();
-    kinds.push(offset32);
+    /// A 32-bit immediate floating point operand.
+    ///
+    /// IEEE 754-2008 binary32 interchange format.
+    pub ieee32: OperandKind,
 
-    // A 32-bit immediate floating point operand.
-    //
-    // IEEE 754-2008 binary32 interchange format.
-    let ieee32 = Builder::new_imm("ieee32")
-        .doc("A 32-bit immediate floating point number.")
-        .build();
-    kinds.push(ieee32);
+    /// A 64-bit immediate floating point operand.
+    ///
+    /// IEEE 754-2008 binary64 interchange format.
+    pub ieee64: OperandKind,
 
-    // A 64-bit immediate floating point operand.
-    //
-    // IEEE 754-2008 binary64 interchange format.
-    let ieee64 = Builder::new_imm("ieee64")
-        .doc("A 64-bit immediate floating point number.")
-        .build();
-    kinds.push(ieee64);
+    /// An immediate boolean operand.
+    ///
+    /// This type of immediate boolean can interact with SSA values with any BoolType type.
+    pub boolean: OperandKind,
 
-    // An immediate boolean operand.
-    //
-    // This type of immediate boolean can interact with SSA values with any
-    // BoolType type.
-    let boolean = Builder::new_imm("boolean")
-        .doc("An immediate boolean.")
-        .rust_type("bool")
-        .build();
-    kinds.push(boolean);
+    /// A condition code for comparing integer values.
+    ///
+    /// This enumerated operand kind is used for the `icmp` instruction and corresponds to the
+    /// condcodes::IntCC` Rust type.
+    pub intcc: OperandKind,
 
-    // A condition code for comparing integer values.
-    // This enumerated operand kind is used for the `icmp` instruction and corresponds to the
-    // condcodes::IntCC` Rust type.
-    let mut intcc_values = HashMap::new();
-    intcc_values.insert("eq", "Equal");
-    intcc_values.insert("ne", "NotEqual");
-    intcc_values.insert("sge", "SignedGreaterThanOrEqual");
-    intcc_values.insert("sgt", "SignedGreaterThan");
-    intcc_values.insert("sle", "SignedLessThanOrEqual");
-    intcc_values.insert("slt", "SignedLessThan");
-    intcc_values.insert("uge", "UnsignedGreaterThanOrEqual");
-    intcc_values.insert("ugt", "UnsignedGreaterThan");
-    intcc_values.insert("ule", "UnsignedLessThanOrEqual");
-    intcc_values.insert("ult", "UnsignedLessThan");
-    let intcc = Builder::new_enum("intcc", intcc_values)
-        .doc("An integer comparison condition code.")
-        .default_member("cond")
-        .rust_type("ir::condcodes::IntCC")
-        .build();
-    kinds.push(intcc);
+    /// A condition code for comparing floating point values.
+    ///
+    /// This enumerated operand kind is used for the `fcmp` instruction and corresponds to the
+    /// `condcodes::FloatCC` Rust type.
+    pub floatcc: OperandKind,
 
-    // A condition code for comparing floating point values.  This enumerated operand kind is used
-    // for the `fcmp` instruction and corresponds to the `condcodes::FloatCC` Rust type.
-    let mut floatcc_values = HashMap::new();
-    floatcc_values.insert("ord", "Ordered");
-    floatcc_values.insert("uno", "Unordered");
-    floatcc_values.insert("eq", "Equal");
-    floatcc_values.insert("ne", "NotEqual");
-    floatcc_values.insert("one", "OrderedNotEqual");
-    floatcc_values.insert("ueq", "UnorderedOrEqual");
-    floatcc_values.insert("lt", "LessThan");
-    floatcc_values.insert("le", "LessThanOrEqual");
-    floatcc_values.insert("gt", "GreaterThan");
-    floatcc_values.insert("ge", "GreaterThanOrEqual");
-    floatcc_values.insert("ult", "UnorderedOrLessThan");
-    floatcc_values.insert("ule", "UnorderedOrLessThanOrEqual");
-    floatcc_values.insert("ugt", "UnorderedOrGreaterThan");
-    floatcc_values.insert("uge", "UnorderedOrGreaterThanOrEqual");
-    let floatcc = Builder::new_enum("floatcc", floatcc_values)
-        .doc("A floating point comparison condition code")
-        .default_member("cond")
-        .rust_type("ir::condcodes::FloatCC")
-        .build();
-    kinds.push(floatcc);
+    /// Flags for memory operations like `load` and `store`.
+    pub memflags: OperandKind,
 
-    // Flags for memory operations like :clif:inst:`load` and :clif:inst:`store`.
-    let memflags = Builder::new_imm("memflags")
-        .doc("Memory operation flags")
-        .default_member("flags")
-        .rust_type("ir::MemFlags")
-        .build();
-    kinds.push(memflags);
+    /// A register unit in the current target ISA.
+    pub regunit: OperandKind,
 
-    // A register unit in the current target ISA.
-    let regunit = Builder::new_imm("regunit")
-        .doc("A register unit in the target ISA")
-        .rust_type("isa::RegUnit")
-        .build();
-    kinds.push(regunit);
+    /// A trap code indicating the reason for trapping.
+    ///
+    /// The Rust enum type also has a `User(u16)` variant for user-provided trap codes.
+    pub trapcode: OperandKind,
+}
 
-    // A trap code indicating the reason for trapping.
-    //
-    // The Rust enum type also has a `User(u16)` variant for user-provided trap
-    // codes.
-    let mut trapcode_values = HashMap::new();
-    trapcode_values.insert("stk_ovf", "StackOverflow");
-    trapcode_values.insert("heap_oob", "HeapOutOfBounds");
-    trapcode_values.insert("int_ovf", "IntegerOverflow");
-    trapcode_values.insert("int_divz", "IntegerDivisionByZero");
-    let trapcode = Builder::new_enum("trapcode", trapcode_values)
-        .doc("A trap reason code.")
-        .default_member("code")
-        .rust_type("ir::TrapCode")
-        .build();
-    kinds.push(trapcode);
+impl Immediates {
+    pub fn new() -> Self {
+        Self {
+            imm64: Builder::new_imm("imm64")
+                .doc("A 64-bit immediate integer.")
+                .build(),
 
-    return kinds;
+            uimm8: Builder::new_imm("uimm8")
+                .doc("An 8-bit immediate unsigned integer.")
+                .build(),
+
+            uimm32: Builder::new_imm("uimm32")
+                .doc("A 32-bit immediate unsigned integer.")
+                .build(),
+
+            uimm128: Builder::new_imm("uimm128")
+                .doc("A 128-bit immediate unsigned integer.")
+                .rust_type("ir::Constant")
+                .build(),
+
+            offset32: Builder::new_imm("offset32")
+                .doc("A 32-bit immediate signed offset.")
+                .default_member("offset")
+                .build(),
+
+            ieee32: Builder::new_imm("ieee32")
+                .doc("A 32-bit immediate floating point number.")
+                .build(),
+
+            ieee64: Builder::new_imm("ieee64")
+                .doc("A 64-bit immediate floating point number.")
+                .build(),
+
+            boolean: Builder::new_imm("boolean")
+                .doc("An immediate boolean.")
+                .rust_type("bool")
+                .build(),
+
+            intcc: {
+                let mut intcc_values = HashMap::new();
+                intcc_values.insert("eq", "Equal");
+                intcc_values.insert("ne", "NotEqual");
+                intcc_values.insert("sge", "SignedGreaterThanOrEqual");
+                intcc_values.insert("sgt", "SignedGreaterThan");
+                intcc_values.insert("sle", "SignedLessThanOrEqual");
+                intcc_values.insert("slt", "SignedLessThan");
+                intcc_values.insert("uge", "UnsignedGreaterThanOrEqual");
+                intcc_values.insert("ugt", "UnsignedGreaterThan");
+                intcc_values.insert("ule", "UnsignedLessThanOrEqual");
+                intcc_values.insert("ult", "UnsignedLessThan");
+                Builder::new_enum("intcc", intcc_values)
+                    .doc("An integer comparison condition code.")
+                    .default_member("cond")
+                    .rust_type("ir::condcodes::IntCC")
+                    .build()
+            },
+
+            floatcc: {
+                let mut floatcc_values = HashMap::new();
+                floatcc_values.insert("ord", "Ordered");
+                floatcc_values.insert("uno", "Unordered");
+                floatcc_values.insert("eq", "Equal");
+                floatcc_values.insert("ne", "NotEqual");
+                floatcc_values.insert("one", "OrderedNotEqual");
+                floatcc_values.insert("ueq", "UnorderedOrEqual");
+                floatcc_values.insert("lt", "LessThan");
+                floatcc_values.insert("le", "LessThanOrEqual");
+                floatcc_values.insert("gt", "GreaterThan");
+                floatcc_values.insert("ge", "GreaterThanOrEqual");
+                floatcc_values.insert("ult", "UnorderedOrLessThan");
+                floatcc_values.insert("ule", "UnorderedOrLessThanOrEqual");
+                floatcc_values.insert("ugt", "UnorderedOrGreaterThan");
+                floatcc_values.insert("uge", "UnorderedOrGreaterThanOrEqual");
+                Builder::new_enum("floatcc", floatcc_values)
+                    .doc("A floating point comparison condition code")
+                    .default_member("cond")
+                    .rust_type("ir::condcodes::FloatCC")
+                    .build()
+            },
+
+            memflags: Builder::new_imm("memflags")
+                .doc("Memory operation flags")
+                .default_member("flags")
+                .rust_type("ir::MemFlags")
+                .build(),
+
+            regunit: Builder::new_imm("regunit")
+                .doc("A register unit in the target ISA")
+                .rust_type("isa::RegUnit")
+                .build(),
+
+            trapcode: {
+                let mut trapcode_values = HashMap::new();
+                trapcode_values.insert("stk_ovf", "StackOverflow");
+                trapcode_values.insert("heap_oob", "HeapOutOfBounds");
+                trapcode_values.insert("int_ovf", "IntegerOverflow");
+                trapcode_values.insert("int_divz", "IntegerDivisionByZero");
+                Builder::new_enum("trapcode", trapcode_values)
+                    .doc("A trap reason code.")
+                    .default_member("code")
+                    .rust_type("ir::TrapCode")
+                    .build()
+            },
+        }
+    }
 }

--- a/cranelift-codegen/meta/src/shared/instructions.rs
+++ b/cranelift-codegen/meta/src/shared/instructions.rs
@@ -11,7 +11,7 @@ use crate::cdsl::typevar::{Interval, TypeSetBuilder, TypeVar};
 use crate::shared::types;
 use crate::shared::{entities::EntityRefs, immediates::Immediates};
 
-pub fn define(
+pub(crate) fn define(
     all_instructions: &mut AllInstructions,
     format_registry: &FormatRegistry,
     imm: &Immediates,

--- a/cranelift-codegen/meta/src/shared/instructions.rs
+++ b/cranelift-codegen/meta/src/shared/instructions.rs
@@ -964,6 +964,34 @@ pub(crate) fn define(
         .operands_out(vec![addr]),
     );
 
+    // Note this instruction is marked as having other side-effects, so GVN won't try to hoist it,
+    // which would result in it being subject to spilling. While not hoisting would generally hurt
+    // performance, since a computed value used many times may need to be regenerated before each
+    // use, it is not the case here: this instruction doesn't generate any code.  That's because,
+    // by definition the pinned register is never used by the register allocator, but is written to
+    // and read explicitly and exclusively by set_pinned_reg and get_pinned_reg.
+    ig.push(
+        Inst::new(
+            "get_pinned_reg",
+            r#"
+            Gets the content of the pinned register, when it's enabled.
+        "#,
+        )
+        .operands_out(vec![addr])
+        .other_side_effects(true),
+    );
+
+    ig.push(
+        Inst::new(
+            "set_pinned_reg",
+            r#"
+        Sets the content of the pinned register, when it's enabled.
+        "#,
+        )
+        .operands_in(vec![addr])
+        .other_side_effects(true),
+    );
+
     let TableOffset = &TypeVar::new(
         "TableOffset",
         "An unsigned table offset",

--- a/cranelift-codegen/meta/src/shared/instructions.rs
+++ b/cranelift-codegen/meta/src/shared/instructions.rs
@@ -3143,7 +3143,7 @@ pub(crate) fn define(
         "WideInt",
         "An integer type with lanes from `i16` upwards",
         TypeSetBuilder::new()
-            .ints(16..64)
+            .ints(16..128)
             .simd_lanes(Interval::All)
             .build(),
     );
@@ -3171,9 +3171,9 @@ pub(crate) fn define(
 
     let NarrowInt = &TypeVar::new(
         "NarrowInt",
-        "An integer type with lanes type to `i32`",
+        "An integer type with lanes type to `i64`",
         TypeSetBuilder::new()
-            .ints(8..32)
+            .ints(8..64)
             .simd_lanes(Interval::All)
             .build(),
     );

--- a/cranelift-codegen/meta/src/shared/instructions.rs
+++ b/cranelift-codegen/meta/src/shared/instructions.rs
@@ -1866,8 +1866,8 @@ pub fn define(
     let y = &operand("y", iB);
     let c_in = &operand_doc("c_in", iflags, "Input carry flag");
     let c_out = &operand_doc("c_out", iflags, "Output carry flag");
-    let b_in = &operand_doc("b_in", b1, "Input borrow flag");
-    let b_out = &operand_doc("b_out", b1, "Output borrow flag");
+    let b_in = &operand_doc("b_in", iflags, "Input borrow flag");
+    let b_out = &operand_doc("b_out", iflags, "Output borrow flag");
 
     ig.push(
         Inst::new(

--- a/cranelift-codegen/meta/src/shared/instructions.rs
+++ b/cranelift-codegen/meta/src/shared/instructions.rs
@@ -1864,8 +1864,8 @@ pub fn define(
     let a = &operand("a", iB);
     let x = &operand("x", iB);
     let y = &operand("y", iB);
-    let c_in = &operand_doc("c_in", b1, "Input carry flag");
-    let c_out = &operand_doc("c_out", b1, "Output carry flag");
+    let c_in = &operand_doc("c_in", iflags, "Input carry flag");
+    let c_out = &operand_doc("c_out", iflags, "Output carry flag");
     let b_in = &operand_doc("b_in", b1, "Input borrow flag");
     let b_out = &operand_doc("b_out", b1, "Output borrow flag");
 

--- a/cranelift-codegen/meta/src/shared/legalize.rs
+++ b/cranelift-codegen/meta/src/shared/legalize.rs
@@ -1,5 +1,5 @@
 use crate::cdsl::ast::{var, ExprBuilder, Literal};
-use crate::cdsl::instructions::{Instruction, InstructionGroup};
+use crate::cdsl::instructions::{Bindable, Instruction, InstructionGroup};
 use crate::cdsl::xform::{TransformGroupBuilder, TransformGroups};
 
 use crate::shared::immediates::Immediates;

--- a/cranelift-codegen/meta/src/shared/legalize.rs
+++ b/cranelift-codegen/meta/src/shared/legalize.rs
@@ -6,7 +6,7 @@ use crate::shared::immediates::Immediates;
 use crate::shared::types::Float::{F32, F64};
 use crate::shared::types::Int::{I16, I32, I64, I8};
 
-pub fn define(insts: &InstructionGroup, imm: &Immediates) -> TransformGroups {
+pub(crate) fn define(insts: &InstructionGroup, imm: &Immediates) -> TransformGroups {
     let mut narrow = TransformGroupBuilder::new(
         "narrow",
         r#"

--- a/cranelift-codegen/meta/src/shared/legalize.rs
+++ b/cranelift-codegen/meta/src/shared/legalize.rs
@@ -207,7 +207,7 @@ pub(crate) fn define(insts: &InstructionGroup, imm: &Immediates) -> TransformGro
         ],
     );
 
-    for &bin_op in &[band, bor, bxor] {
+    for &bin_op in &[band, bor, bxor, band_not, bor_not, bxor_not] {
         narrow.legalize(
             def!(a = bin_op(x, y)),
             vec![
@@ -219,6 +219,16 @@ pub(crate) fn define(insts: &InstructionGroup, imm: &Immediates) -> TransformGro
             ],
         );
     }
+
+    narrow.legalize(
+        def!(a = bnot(x)),
+        vec![
+            def!((xl, xh) = isplit(x)),
+            def!(al = bnot(xl)),
+            def!(ah = bnot(xh)),
+            def!(a = iconcat(al, ah)),
+        ],
+    );
 
     narrow.legalize(
         def!(a = select(c, x, y)),

--- a/cranelift-codegen/meta/src/shared/legalize.rs
+++ b/cranelift-codegen/meta/src/shared/legalize.rs
@@ -185,6 +185,9 @@ pub(crate) fn define(insts: &InstructionGroup, imm: &Immediates) -> TransformGro
     let offset = var("off");
     let vararg = var("vararg");
 
+    narrow.custom_legalize(load, "narrow_load");
+    narrow.custom_legalize(store, "narrow_store");
+
     narrow.legalize(
         def!(a = iadd(x, y)),
         vec![
@@ -270,30 +273,6 @@ pub(crate) fn define(insts: &InstructionGroup, imm: &Immediates) -> TransformGro
             def!((xl, xh) = isplit(x)),
             def!(brnz(xl, ebb, vararg)),
             def!(brnz(xh, ebb, vararg)),
-        ],
-    );
-
-    // FIXME generalize to any offset once offset+8 can be represented
-    narrow.legalize(
-        def!(a = load.I128(flags, ptr, Literal::constant(&imm.offset32, 0))),
-        vec![
-            def!(al = load.I64(flags, ptr, Literal::constant(&imm.offset32, 0))),
-            def!(ah = load.I64(flags, ptr, Literal::constant(&imm.offset32, 8))),
-            // `iconcat` expects the same byte order as stored in memory,
-            // so no need to swap depending on endianness.
-            def!(a = iconcat(al, ah)),
-        ],
-    );
-
-    // FIXME generalize to any offset once offset+8 can be represented
-    narrow.legalize(
-        def!(store.I128(flags, a, ptr, Literal::constant(&imm.offset32, 0))),
-        vec![
-            // `isplit` gives the same byte order as stored in memory,
-            // so no need to swap depending on endianness.
-            def!((al, ah) = isplit(a)),
-            def!(store.I64(flags, al, ptr, Literal::constant(&imm.offset32, 0))),
-            def!(store.I64(flags, ah, ptr, Literal::constant(&imm.offset32, 8))),
         ],
     );
 

--- a/cranelift-codegen/meta/src/shared/legalize.rs
+++ b/cranelift-codegen/meta/src/shared/legalize.rs
@@ -86,7 +86,6 @@ pub fn define(insts: &InstructionGroup, immediates: &OperandKinds) -> TransformG
     let istore16 = insts.by_name("istore16");
     let isub = insts.by_name("isub");
     let isub_bin = insts.by_name("isub_bin");
-    let isub_borrow = insts.by_name("isub_borrow");
     let isub_bout = insts.by_name("isub_bout");
     let load = insts.by_name("load");
     let popcnt = insts.by_name("popcnt");
@@ -160,8 +159,6 @@ pub fn define(insts: &InstructionGroup, immediates: &OperandKinds) -> TransformG
     let b2 = var("b2");
     let b3 = var("b3");
     let b4 = var("b4");
-    let b_in = var("b_in");
-    let b_int = var("b_int");
     let c = var("c");
     let c1 = var("c1");
     let c2 = var("c2");
@@ -458,33 +455,6 @@ pub fn define(insts: &InstructionGroup, immediates: &OperandKinds) -> TransformG
             );
         }
     }
-
-    // Expand integer operations with carry for RISC architectures that don't have
-    // the flags.
-    let intcc_ugt = Literal::enumerator_for(intcc, "ugt");
-    expand.legalize(
-        def!((a, b) = isub_bout(x, y)),
-        vec![def!(a = isub(x, y)), def!(b = icmp(intcc_ugt, a, x))],
-    );
-
-    expand.legalize(
-        def!(a = isub_bin(x, y, b)),
-        vec![
-            def!(a1 = isub(x, y)),
-            def!(b_int = bint(b)),
-            def!(a = isub(a1, b_int)),
-        ],
-    );
-
-    expand.legalize(
-        def!((a, b) = isub_borrow(x, y, b_in)),
-        vec![
-            def!((a1, b1) = isub_bout(x, y)),
-            def!(b_int = bint(b_in)),
-            def!((a, b2) = isub_bout(a1, b_int)),
-            def!(b = bor(b1, b2)),
-        ],
-    );
 
     // Expansions for fcvt_from_{u,s}int for smaller integer types.
     // These use expand and not widen because the controlling type variable for

--- a/cranelift-codegen/meta/src/shared/legalize.rs
+++ b/cranelift-codegen/meta/src/shared/legalize.rs
@@ -4,7 +4,7 @@ use crate::cdsl::xform::{TransformGroupBuilder, TransformGroups};
 
 use crate::shared::immediates::Immediates;
 use crate::shared::types::Float::{F32, F64};
-use crate::shared::types::Int::{I16, I128, I32, I64, I8};
+use crate::shared::types::Int::{I128, I16, I32, I64, I8};
 
 pub(crate) fn define(insts: &InstructionGroup, imm: &Immediates) -> TransformGroups {
     let mut narrow = TransformGroupBuilder::new(
@@ -245,8 +245,20 @@ pub(crate) fn define(insts: &InstructionGroup, imm: &Immediates) -> TransformGro
         def!(brz.I128(x, ebb, vararg)),
         vec![
             def!((xl, xh) = isplit(x)),
-            def!(a = icmp_imm(Literal::enumerator_for(intcc, "eq"), xl, Literal::constant(imm64, 0))),
-            def!(b = icmp_imm(Literal::enumerator_for(intcc, "eq"), xh, Literal::constant(imm64, 0))),
+            def!(
+                a = icmp_imm(
+                    Literal::enumerator_for(intcc, "eq"),
+                    xl,
+                    Literal::constant(imm64, 0)
+                )
+            ),
+            def!(
+                b = icmp_imm(
+                    Literal::enumerator_for(intcc, "eq"),
+                    xh,
+                    Literal::constant(imm64, 0)
+                )
+            ),
             def!(c = band(a, b)),
             def!(brz(c, ebb, vararg)),
         ],

--- a/cranelift-codegen/meta/src/shared/legalize.rs
+++ b/cranelift-codegen/meta/src/shared/legalize.rs
@@ -66,7 +66,6 @@ pub fn define(insts: &InstructionGroup, immediates: &OperandKinds) -> TransformG
     let fcvt_from_uint = insts.by_name("fcvt_from_uint");
     let fneg = insts.by_name("fneg");
     let iadd = insts.by_name("iadd");
-    let iadd_carry = insts.by_name("iadd_carry");
     let iadd_cin = insts.by_name("iadd_cin");
     let iadd_cout = insts.by_name("iadd_cout");
     let iadd_imm = insts.by_name("iadd_imm");
@@ -168,8 +167,6 @@ pub fn define(insts: &InstructionGroup, immediates: &OperandKinds) -> TransformG
     let c2 = var("c2");
     let c3 = var("c3");
     let c4 = var("c4");
-    let c_in = var("c_in");
-    let c_int = var("c_int");
     let d = var("d");
     let d1 = var("d1");
     let d2 = var("d2");
@@ -464,25 +461,10 @@ pub fn define(insts: &InstructionGroup, immediates: &OperandKinds) -> TransformG
 
     // Expand integer operations with carry for RISC architectures that don't have
     // the flags.
-    let intcc_ult = Literal::enumerator_for(intcc, "ult");
-    expand.legalize(
-        def!((a, c) = iadd_cout(x, y)),
-        vec![def!(a = iadd(x, y)), def!(c = icmp(intcc_ult, a, x))],
-    );
-
     let intcc_ugt = Literal::enumerator_for(intcc, "ugt");
     expand.legalize(
         def!((a, b) = isub_bout(x, y)),
         vec![def!(a = isub(x, y)), def!(b = icmp(intcc_ugt, a, x))],
-    );
-
-    expand.legalize(
-        def!(a = iadd_cin(x, y, c)),
-        vec![
-            def!(a1 = iadd(x, y)),
-            def!(c_int = bint(c)),
-            def!(a = iadd(a1, c_int)),
-        ],
     );
 
     expand.legalize(
@@ -491,16 +473,6 @@ pub fn define(insts: &InstructionGroup, immediates: &OperandKinds) -> TransformG
             def!(a1 = isub(x, y)),
             def!(b_int = bint(b)),
             def!(a = isub(a1, b_int)),
-        ],
-    );
-
-    expand.legalize(
-        def!((a, c) = iadd_carry(x, y, c_in)),
-        vec![
-            def!((a1, c1) = iadd_cout(x, y)),
-            def!(c_int = bint(c_in)),
-            def!((a, c2) = iadd_cout(a1, c_int)),
-            def!(c = bor(c1, c2)),
         ],
     );
 

--- a/cranelift-codegen/meta/src/shared/mod.rs
+++ b/cranelift-codegen/meta/src/shared/mod.rs
@@ -1,6 +1,6 @@
 //! Shared definitions for the Cranelift intermediate language.
 
-pub mod entities;
+mod entities;
 pub mod formats;
 pub mod immediates;
 pub mod instructions;
@@ -10,10 +10,10 @@ pub mod types;
 
 use crate::cdsl::formats::FormatRegistry;
 use crate::cdsl::instructions::{AllInstructions, InstructionGroup};
-use crate::cdsl::operands::OperandKind;
 use crate::cdsl::settings::SettingGroup;
 use crate::cdsl::xform::TransformGroups;
 
+use crate::shared::entities::EntityRefs;
 use crate::shared::immediates::Immediates;
 
 pub struct Definitions {
@@ -25,28 +25,11 @@ pub struct Definitions {
     pub transform_groups: TransformGroups,
 }
 
-pub struct OperandKinds(Vec<OperandKind>);
-
-impl OperandKinds {
-    pub fn by_name(&self, name: &'static str) -> &OperandKind {
-        self.0
-            .iter()
-            .find(|op| op.name == name)
-            .expect(&format!("unknown Operand name: {}", name))
-    }
-}
-
-impl From<Vec<OperandKind>> for OperandKinds {
-    fn from(kinds: Vec<OperandKind>) -> Self {
-        OperandKinds(kinds)
-    }
-}
-
 pub fn define() -> Definitions {
     let mut all_instructions = AllInstructions::new();
 
     let immediates = Immediates::new();
-    let entities = OperandKinds(entities::define());
+    let entities = EntityRefs::new();;
     let format_registry = formats::define(&immediates, &entities);
     let instructions = instructions::define(
         &mut all_instructions,

--- a/cranelift-codegen/meta/src/shared/mod.rs
+++ b/cranelift-codegen/meta/src/shared/mod.rs
@@ -16,7 +16,7 @@ use crate::cdsl::xform::TransformGroups;
 use crate::shared::entities::EntityRefs;
 use crate::shared::immediates::Immediates;
 
-pub struct Definitions {
+pub(crate) struct Definitions {
     pub settings: SettingGroup,
     pub all_instructions: AllInstructions,
     pub instructions: InstructionGroup,
@@ -25,7 +25,7 @@ pub struct Definitions {
     pub transform_groups: TransformGroups,
 }
 
-pub fn define() -> Definitions {
+pub(crate) fn define() -> Definitions {
     let mut all_instructions = AllInstructions::new();
 
     let immediates = Immediates::new();

--- a/cranelift-codegen/meta/src/shared/mod.rs
+++ b/cranelift-codegen/meta/src/shared/mod.rs
@@ -14,11 +14,13 @@ use crate::cdsl::operands::OperandKind;
 use crate::cdsl::settings::SettingGroup;
 use crate::cdsl::xform::TransformGroups;
 
+use crate::shared::immediates::Immediates;
+
 pub struct Definitions {
     pub settings: SettingGroup,
     pub all_instructions: AllInstructions,
     pub instructions: InstructionGroup,
-    pub operand_kinds: OperandKinds,
+    pub imm: Immediates,
     pub format_registry: FormatRegistry,
     pub transform_groups: TransformGroups,
 }
@@ -26,27 +28,11 @@ pub struct Definitions {
 pub struct OperandKinds(Vec<OperandKind>);
 
 impl OperandKinds {
-    pub fn new() -> Self {
-        Self(Vec::new())
-    }
-
     pub fn by_name(&self, name: &'static str) -> &OperandKind {
         self.0
             .iter()
             .find(|op| op.name == name)
             .expect(&format!("unknown Operand name: {}", name))
-    }
-
-    pub fn push(&mut self, operand_kind: OperandKind) {
-        assert!(
-            self.0
-                .iter()
-                .find(|existing| existing.name == operand_kind.name)
-                .is_none(),
-            "trying to insert operand kind '{}' for the second time",
-            operand_kind.name
-        );
-        self.0.push(operand_kind);
     }
 }
 
@@ -59,7 +45,7 @@ impl From<Vec<OperandKind>> for OperandKinds {
 pub fn define() -> Definitions {
     let mut all_instructions = AllInstructions::new();
 
-    let immediates = OperandKinds(immediates::define());
+    let immediates = Immediates::new();
     let entities = OperandKinds(entities::define());
     let format_registry = formats::define(&immediates, &entities);
     let instructions = instructions::define(
@@ -74,7 +60,7 @@ pub fn define() -> Definitions {
         settings: settings::define(),
         all_instructions,
         instructions,
-        operand_kinds: immediates,
+        imm: immediates,
         format_registry,
         transform_groups,
     }

--- a/cranelift-codegen/meta/src/shared/settings.rs
+++ b/cranelift-codegen/meta/src/shared/settings.rs
@@ -84,6 +84,17 @@ pub fn define() -> SettingGroup {
         false,
     );
 
+    settings.add_bool(
+        "enable_pinned_reg",
+        r#"Enable the use of the pinned register.
+
+        This register is excluded from register allocation, and is completely under the control of
+        the end-user. It is possible to read it via the get_pinned_reg instruction, and to set it
+        with the set_pinned_reg instruction.
+        "#,
+        false,
+    );
+
     settings.add_bool("enable_simd", "Enable the use of SIMD instructions.", false);
 
     settings.add_bool(

--- a/cranelift-codegen/meta/src/shared/settings.rs
+++ b/cranelift-codegen/meta/src/shared/settings.rs
@@ -95,6 +95,21 @@ pub fn define() -> SettingGroup {
         false,
     );
 
+    settings.add_bool(
+        "use_pinned_reg_as_heap_base",
+        r#"Use the pinned register as the heap base.
+
+        Enabling this requires the enable_pinned_reg setting to be set to true. It enables a custom
+        legalization of the `heap_addr` instruction so it will use the pinned register as the heap
+        base, instead of fetching it from a global value.
+
+        Warning! Enabling this means that the pinned register *must* be maintained to contain the
+        heap base address at all times, during the lifetime of a function. Using the pinned
+        register for other purposes when this is set is very likely to cause crashes.
+        "#,
+        false,
+    );
+
     settings.add_bool("enable_simd", "Enable the use of SIMD instructions.", false);
 
     settings.add_bool(

--- a/cranelift-codegen/meta/src/shared/types.rs
+++ b/cranelift-codegen/meta/src/shared/types.rs
@@ -51,6 +51,8 @@ pub enum Int {
     I32 = 32,
     /// 64-bit int.
     I64 = 64,
+    /// 128-bit int.
+    I128 = 128,
 }
 
 /// This provides an iterator through all of the supported int variants.
@@ -72,6 +74,7 @@ impl Iterator for IntIterator {
             1 => Some(Int::I16),
             2 => Some(Int::I32),
             3 => Some(Int::I64),
+            4 => Some(Int::I128),
             _ => return None,
         };
         self.index += 1;
@@ -199,6 +202,7 @@ mod iter_tests {
         assert_eq!(int_iter.next(), Some(Int::I16));
         assert_eq!(int_iter.next(), Some(Int::I32));
         assert_eq!(int_iter.next(), Some(Int::I64));
+        assert_eq!(int_iter.next(), Some(Int::I128));
         assert_eq!(int_iter.next(), None);
     }
 

--- a/cranelift-codegen/meta/src/shared/types.rs
+++ b/cranelift-codegen/meta/src/shared/types.rs
@@ -12,6 +12,8 @@ pub enum Bool {
     B32 = 32,
     /// 64-bit bool.
     B64 = 64,
+    /// 128-bit bool.
+    B128 = 128,
 }
 
 /// This provides an iterator through all of the supported bool variants.
@@ -34,6 +36,7 @@ impl Iterator for BoolIterator {
             2 => Some(Bool::B16),
             3 => Some(Bool::B32),
             4 => Some(Bool::B64),
+            5 => Some(Bool::B128),
             _ => return None,
         };
         self.index += 1;
@@ -192,6 +195,7 @@ mod iter_tests {
         assert_eq!(bool_iter.next(), Some(Bool::B16));
         assert_eq!(bool_iter.next(), Some(Bool::B32));
         assert_eq!(bool_iter.next(), Some(Bool::B64));
+        assert_eq!(bool_iter.next(), Some(Bool::B128));
         assert_eq!(bool_iter.next(), None);
     }
 

--- a/cranelift-codegen/src/binemit/mod.rs
+++ b/cranelift-codegen/src/binemit/mod.rs
@@ -185,7 +185,7 @@ where
 
     sink.begin_jumptables();
 
-    // output jump tables
+    // Output jump tables.
     for (jt, jt_data) in func.jump_tables.iter() {
         let jt_offset = func.jt_offsets[jt];
         for ebb in jt_data.iter() {
@@ -196,7 +196,7 @@ where
 
     sink.begin_rodata();
 
-    // output constants
+    // Output constants.
     for (_, constant_data) in func.dfg.constants.iter() {
         for byte in constant_data.iter() {
             sink.put1(*byte)

--- a/cranelift-codegen/src/binemit/relaxation.rs
+++ b/cranelift-codegen/src/binemit/relaxation.rs
@@ -169,6 +169,14 @@ fn try_fold_redundant_jump(
         }
     };
 
+    // For the moment, only attempt to fold a branch to an ebb that is parameterless.
+    // These blocks are mainly produced by critical edge splitting.
+    //
+    // TODO: Allow folding blocks that define SSA values and function as phi nodes.
+    if func.dfg.num_ebb_params(first_dest) != 0 {
+        return false;
+    }
+
     // Look at the first instruction of the first branch's destination.
     // If it is an unconditional branch, maybe the second jump can be bypassed.
     let second_inst = func.layout.first_inst(first_dest).expect("Instructions");

--- a/cranelift-codegen/src/binemit/relaxation.rs
+++ b/cranelift-codegen/src/binemit/relaxation.rs
@@ -129,8 +129,7 @@ pub fn relax_branches(
 
     for (jt, jt_data) in func.jump_tables.iter() {
         func.jt_offsets[jt] = offset;
-        // TODO: this should be computed based on the min size needed to hold
-        //        the furthest branch.
+        // TODO: this should be computed based on the min size needed to hold the furthest branch.
         offset += jt_data.len() as u32 * 4;
     }
 

--- a/cranelift-codegen/src/context.rs
+++ b/cranelift-codegen/src/context.rs
@@ -212,7 +212,7 @@ impl Context {
     /// Run the locations verifier on the function.
     pub fn verify_locations(&self, isa: &dyn TargetIsa) -> VerifierResult<()> {
         let mut errors = VerifierErrors::default();
-        let _ = verify_locations(isa, &self.func, None, &mut errors);
+        let _ = verify_locations(isa, &self.func, &self.cfg, None, &mut errors);
 
         if errors.is_empty() {
             Ok(())

--- a/cranelift-codegen/src/ir/dfg.rs
+++ b/cranelift-codegen/src/ir/dfg.rs
@@ -1239,7 +1239,6 @@ mod tests {
 
     #[test]
     fn aliases() {
-        use crate::ir::condcodes::IntCC;
         use crate::ir::InstBuilder;
 
         let mut func = Function::new();
@@ -1264,9 +1263,9 @@ mod tests {
         pos.func.dfg.clear_results(iadd);
         pos.func.dfg.attach_result(iadd, s);
 
-        // Replace `iadd_cout` with a normal `iadd` and an `icmp`.
+        // Replace `iadd_cout` with a normal `iadd` and an `ifcmp`.
         pos.func.dfg.replace(iadd).iadd(v1, arg0);
-        let c2 = pos.ins().icmp(IntCC::UnsignedLessThan, s, v1);
+        let c2 = pos.ins().ifcmp(s, v1);
         pos.func.dfg.change_to_alias(c, c2);
 
         assert_eq!(pos.func.dfg.resolve_aliases(c2), c2);

--- a/cranelift-codegen/src/ir/immediates.rs
+++ b/cranelift-codegen/src/ir/immediates.rs
@@ -292,7 +292,7 @@ impl FromStr for Uimm32 {
 
 /// A 128-bit unsigned integer immediate operand.
 ///
-/// This is used as an immediate value in SIMD instructions
+/// This is used as an immediate value in SIMD instructions.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
 pub struct Uimm128(pub [u8; 16]);
 
@@ -314,7 +314,7 @@ impl Uimm128 {
 }
 
 impl Display for Uimm128 {
-    // print a 128-bit vector in hexadecimal, e.g. 0x000102030405060708090a0b0c0d0e0f
+    // Print a 128-bit vector in hexadecimal, e.g. 0x000102030405060708090a0b0c0d0e0f.
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         write!(f, "0x")?;
         let mut anything_written = false;

--- a/cranelift-codegen/src/ir/types.rs
+++ b/cranelift-codegen/src/ir/types.rs
@@ -10,7 +10,7 @@ use target_lexicon::{PointerWidth, Triple};
 /// field is present put no type is needed, such as the controlling type variable for a
 /// non-polymorphic instruction.
 ///
-/// Basic integer types: `I8`, `I16`, `I32`, and `I64`. These types are sign-agnostic.
+/// Basic integer types: `I8`, `I16`, `I32`, `I64`, and `I128`. These types are sign-agnostic.
 ///
 /// Basic floating point types: `F32` and `F64`. IEEE single and double precision.
 ///

--- a/cranelift-codegen/src/ir/types.rs
+++ b/cranelift-codegen/src/ir/types.rs
@@ -14,7 +14,7 @@ use target_lexicon::{PointerWidth, Triple};
 ///
 /// Basic floating point types: `F32` and `F64`. IEEE single and double precision.
 ///
-/// Boolean types: `B1`, `B8`, `B16`, `B32`, and `B64`. These all encode 'true' or 'false'. The
+/// Boolean types: `B1`, `B8`, `B16`, `B32`, `B64`, and `B128`. These all encode 'true' or 'false'. The
 /// larger types use redundant bits.
 ///
 /// SIMD vector types have power-of-two lanes, up to 256. Lanes can be any int/float/bool type.
@@ -63,7 +63,7 @@ impl Type {
             B16 | I16 => 4,
             B32 | I32 | F32 | R32 => 5,
             B64 | I64 | F64 | R64 => 6,
-            I128 => 7,
+            B128 | I128 => 7,
             _ => 0,
         }
     }
@@ -76,7 +76,7 @@ impl Type {
             B16 | I16 => 16,
             B32 | I32 | F32 | R32 => 32,
             B64 | I64 | F64 | R64 => 64,
-            I128 => 128,
+            B128 | I128 => 128,
             _ => 0,
         }
     }
@@ -112,6 +112,7 @@ impl Type {
             B32 | I32 | F32 => B32,
             B64 | I64 | F64 => B64,
             R32 | R64 => panic!("Reference types should not convert to bool"),
+            B128 | I128 => B128,
             _ => B1,
         })
     }
@@ -140,6 +141,7 @@ impl Type {
             B16 => B8,
             B32 => B16,
             B64 => B32,
+            B128 => B64,
             _ => return None,
         }))
     }
@@ -156,6 +158,7 @@ impl Type {
             B8 => B16,
             B16 => B32,
             B32 => B64,
+            B64 => B128,
             _ => return None,
         }))
     }
@@ -187,7 +190,7 @@ impl Type {
     /// Is this a scalar boolean type?
     pub fn is_bool(self) -> bool {
         match self {
-            B1 | B8 | B16 | B32 | B64 => true,
+            B1 | B8 | B16 | B32 | B64 | B128 => true,
             _ => false,
         }
     }
@@ -375,6 +378,7 @@ mod tests {
         assert_eq!(B16, B16.lane_type());
         assert_eq!(B32, B32.lane_type());
         assert_eq!(B64, B64.lane_type());
+        assert_eq!(B128, B128.lane_type());
         assert_eq!(I8, I8.lane_type());
         assert_eq!(I16, I16.lane_type());
         assert_eq!(I32, I32.lane_type());
@@ -396,6 +400,7 @@ mod tests {
         assert_eq!(B16.lane_bits(), 16);
         assert_eq!(B32.lane_bits(), 32);
         assert_eq!(B64.lane_bits(), 64);
+        assert_eq!(B128.lane_bits(), 128);
         assert_eq!(I8.lane_bits(), 8);
         assert_eq!(I16.lane_bits(), 16);
         assert_eq!(I32.lane_bits(), 32);
@@ -417,6 +422,7 @@ mod tests {
         assert_eq!(B16.half_width(), Some(B8));
         assert_eq!(B32.half_width(), Some(B16));
         assert_eq!(B64.half_width(), Some(B32));
+        assert_eq!(B128.half_width(), Some(B64));
         assert_eq!(I8.half_width(), None);
         assert_eq!(I16.half_width(), Some(I8));
         assert_eq!(I32.half_width(), Some(I16));
@@ -433,7 +439,8 @@ mod tests {
         assert_eq!(B8.double_width(), Some(B16));
         assert_eq!(B16.double_width(), Some(B32));
         assert_eq!(B32.double_width(), Some(B64));
-        assert_eq!(B64.double_width(), None);
+        assert_eq!(B64.double_width(), Some(B128));
+        assert_eq!(B128.double_width(), None);
         assert_eq!(I8.double_width(), Some(I16));
         assert_eq!(I16.double_width(), Some(I32));
         assert_eq!(I32.double_width(), Some(I64));
@@ -470,6 +477,7 @@ mod tests {
         assert_eq!(B16.to_string(), "b16");
         assert_eq!(B32.to_string(), "b32");
         assert_eq!(B64.to_string(), "b64");
+        assert_eq!(B128.to_string(), "b128");
         assert_eq!(I8.to_string(), "i8");
         assert_eq!(I16.to_string(), "i16");
         assert_eq!(I32.to_string(), "i32");

--- a/cranelift-codegen/src/ir/types.rs
+++ b/cranelift-codegen/src/ir/types.rs
@@ -63,6 +63,7 @@ impl Type {
             B16 | I16 => 4,
             B32 | I32 | F32 | R32 => 5,
             B64 | I64 | F64 | R64 => 6,
+            I128 => 7,
             _ => 0,
         }
     }
@@ -75,6 +76,7 @@ impl Type {
             B16 | I16 => 16,
             B32 | I32 | F32 | R32 => 32,
             B64 | I64 | F64 | R64 => 64,
+            I128 => 128,
             _ => 0,
         }
     }
@@ -86,6 +88,7 @@ impl Type {
             16 => Some(I16),
             32 => Some(I32),
             64 => Some(I64),
+            128 => Some(I128),
             _ => None,
         }
     }
@@ -132,6 +135,7 @@ impl Type {
             I16 => I8,
             I32 => I16,
             I64 => I32,
+            I128 => I64,
             F64 => F32,
             B16 => B8,
             B32 => B16,
@@ -147,6 +151,7 @@ impl Type {
             I8 => I16,
             I16 => I32,
             I32 => I64,
+            I64 => I128,
             F32 => F64,
             B8 => B16,
             B16 => B32,
@@ -190,7 +195,7 @@ impl Type {
     /// Is this a scalar integer type?
     pub fn is_int(self) -> bool {
         match self {
-            I8 | I16 | I32 | I64 => true,
+            I8 | I16 | I32 | I64 | I128 => true,
             _ => false,
         }
     }
@@ -374,6 +379,7 @@ mod tests {
         assert_eq!(I16, I16.lane_type());
         assert_eq!(I32, I32.lane_type());
         assert_eq!(I64, I64.lane_type());
+        assert_eq!(I128, I128.lane_type());
         assert_eq!(F32, F32.lane_type());
         assert_eq!(F64, F64.lane_type());
         assert_eq!(B1, B1.by(8).unwrap().lane_type());
@@ -394,6 +400,7 @@ mod tests {
         assert_eq!(I16.lane_bits(), 16);
         assert_eq!(I32.lane_bits(), 32);
         assert_eq!(I64.lane_bits(), 64);
+        assert_eq!(I128.lane_bits(), 128);
         assert_eq!(F32.lane_bits(), 32);
         assert_eq!(F64.lane_bits(), 64);
         assert_eq!(R32.lane_bits(), 32);
@@ -415,6 +422,7 @@ mod tests {
         assert_eq!(I32.half_width(), Some(I16));
         assert_eq!(I32X4.half_width(), Some(I16X4));
         assert_eq!(I64.half_width(), Some(I32));
+        assert_eq!(I128.half_width(), Some(I64));
         assert_eq!(F32.half_width(), None);
         assert_eq!(F64.half_width(), Some(F32));
 
@@ -430,7 +438,8 @@ mod tests {
         assert_eq!(I16.double_width(), Some(I32));
         assert_eq!(I32.double_width(), Some(I64));
         assert_eq!(I32X4.double_width(), Some(I64X4));
-        assert_eq!(I64.double_width(), None);
+        assert_eq!(I64.double_width(), Some(I128));
+        assert_eq!(I128.double_width(), None);
         assert_eq!(F32.double_width(), Some(F64));
         assert_eq!(F64.double_width(), None);
     }
@@ -465,6 +474,7 @@ mod tests {
         assert_eq!(I16.to_string(), "i16");
         assert_eq!(I32.to_string(), "i32");
         assert_eq!(I64.to_string(), "i64");
+        assert_eq!(I128.to_string(), "i128");
         assert_eq!(F32.to_string(), "f32");
         assert_eq!(F64.to_string(), "f64");
         assert_eq!(R32.to_string(), "r32");

--- a/cranelift-codegen/src/isa/mod.rs
+++ b/cranelift-codegen/src/isa/mod.rs
@@ -88,18 +88,17 @@ pub mod registers;
 mod stack;
 
 /// Returns a builder that can create a corresponding `TargetIsa`
-/// or `Err(LookupError::Unsupported)` if not enabled.
+/// or `Err(LookupError::SupportDisabled)` if not enabled.
 macro_rules! isa_builder {
-    ($name:ident, $feature:tt) => {{
+    ($name: ident, $feature: tt, $triple: ident) => {{
         #[cfg(feature = $feature)]
-        fn $name(triple: Triple) -> Result<Builder, LookupError> {
-            Ok($name::isa_builder(triple))
-        };
+        {
+            Ok($name::isa_builder($triple))
+        }
         #[cfg(not(feature = $feature))]
-        fn $name(_triple: Triple) -> Result<Builder, LookupError> {
+        {
             Err(LookupError::SupportDisabled)
         }
-        $name
     }};
 }
 
@@ -107,12 +106,12 @@ macro_rules! isa_builder {
 /// Return a builder that can create a corresponding `TargetIsa`.
 pub fn lookup(triple: Triple) -> Result<Builder, LookupError> {
     match triple.architecture {
-        Architecture::Riscv32 | Architecture::Riscv64 => isa_builder!(riscv, "riscv")(triple),
+        Architecture::Riscv32 | Architecture::Riscv64 => isa_builder!(riscv, "riscv", triple),
         Architecture::I386 | Architecture::I586 | Architecture::I686 | Architecture::X86_64 => {
-            isa_builder!(x86, "x86")(triple)
+            isa_builder!(x86, "x86", triple)
         }
-        Architecture::Arm { .. } => isa_builder!(arm32, "arm32")(triple),
-        Architecture::Aarch64 { .. } => isa_builder!(arm64, "arm64")(triple),
+        Architecture::Arm { .. } => isa_builder!(arm32, "arm32", triple),
+        Architecture::Aarch64 { .. } => isa_builder!(arm64, "arm64", triple),
         _ => Err(LookupError::Unsupported),
     }
 }

--- a/cranelift-codegen/src/isa/mod.rs
+++ b/cranelift-codegen/src/isa/mod.rs
@@ -66,7 +66,7 @@ use crate::timing;
 use core::fmt;
 use failure_derive::Fail;
 use std::boxed::Box;
-use target_lexicon::{Architecture, PointerWidth, Triple};
+use target_lexicon::{triple, Architecture, PointerWidth, Triple};
 
 #[cfg(feature = "riscv")]
 mod riscv;
@@ -97,13 +97,13 @@ macro_rules! isa_builder {
         };
         #[cfg(not(feature = $feature))]
         fn $name(_triple: Triple) -> Result<Builder, LookupError> {
-            Err(LookupError::Unsupported)
+            Err(LookupError::SupportDisabled)
         }
         $name
     }};
 }
 
-/// Look for a supported ISA with the given `name`.
+/// Look for an ISA for the given `triple`.
 /// Return a builder that can create a corresponding `TargetIsa`.
 pub fn lookup(triple: Triple) -> Result<Builder, LookupError> {
     match triple.architecture {
@@ -115,6 +115,13 @@ pub fn lookup(triple: Triple) -> Result<Builder, LookupError> {
         Architecture::Aarch64 { .. } => isa_builder!(arm64, "arm64")(triple),
         _ => Err(LookupError::Unsupported),
     }
+}
+
+/// Look for a supported ISA with the given `name`.
+/// Return a builder that can create a corresponding `TargetIsa`.
+pub fn lookup_by_name(name: &str) -> Result<Builder, LookupError> {
+    use std::str::FromStr;
+    lookup(triple!(name))
 }
 
 /// Describes reason for target lookup failure

--- a/cranelift-codegen/src/isa/registers.rs
+++ b/cranelift-codegen/src/isa/registers.rs
@@ -154,6 +154,12 @@ pub struct RegClassData {
 
     /// The global `RegInfo` instance containing this register class.
     pub info: &'static RegInfo,
+
+    /// The "pinned" register of the associated register bank.
+    ///
+    /// This register must be non-volatile (callee-preserved) and must not be the fixed
+    /// output register of any instruction.
+    pub pinned_reg: Option<RegUnit>,
 }
 
 impl RegClassData {
@@ -200,6 +206,15 @@ impl RegClassData {
     /// Does this register class contain `regunit`?
     pub fn contains(&self, regunit: RegUnit) -> bool {
         self.mask[(regunit / 32) as usize] & (1u32 << (regunit % 32)) != 0
+    }
+
+    /// If the pinned register is used, is the given regunit the pinned register of this class?
+    #[inline]
+    pub fn is_pinned_reg(&self, enabled: bool, regunit: RegUnit) -> bool {
+        enabled
+            && self
+                .pinned_reg
+                .map_or(false, |pinned_reg| pinned_reg == regunit)
     }
 }
 

--- a/cranelift-codegen/src/isa/x86/abi.rs
+++ b/cranelift-codegen/src/isa/x86/abi.rs
@@ -89,9 +89,8 @@ impl ArgAssigner for Args {
                 let reg = FPR.unit(self.fpr_used);
                 self.fpr_used += 1;
                 return ArgumentLoc::Reg(reg).into();
-            } else {
-                return ValueConversion::VectorSplit.into();
             }
+            return ValueConversion::VectorSplit.into();
         }
 
         // Large integers and booleans are broken down to fit in a register.
@@ -229,7 +228,7 @@ pub fn regclass_for_abi_type(ty: ir::Type) -> RegClass {
 }
 
 /// Get the set of allocatable registers for `func`.
-pub fn allocatable_registers(_func: &ir::Function, triple: &Triple) -> RegisterSet {
+pub fn allocatable_registers(triple: &Triple, flags: &shared_settings::Flags) -> RegisterSet {
     let mut regs = RegisterSet::new();
     regs.take(GPR, RU::rsp as RegUnit);
     regs.take(GPR, RU::rbp as RegUnit);
@@ -239,6 +238,15 @@ pub fn allocatable_registers(_func: &ir::Function, triple: &Triple) -> RegisterS
         for i in 8..16 {
             regs.take(GPR, GPR.unit(i));
             regs.take(FPR, FPR.unit(i));
+        }
+        if flags.enable_pinned_reg() {
+            unimplemented!("Pinned register not implemented on x86-32.");
+        }
+    } else {
+        // Choose r15 as the pinned register on 64-bits: it is non-volatile on native ABIs and
+        // isn't the fixed output register of any instruction.
+        if flags.enable_pinned_reg() {
+            regs.take(GPR, RU::r15 as RegUnit);
         }
     }
 

--- a/cranelift-codegen/src/isa/x86/mod.rs
+++ b/cranelift-codegen/src/isa/x86/mod.rs
@@ -119,8 +119,8 @@ impl TargetIsa for Isa {
         abi::regclass_for_abi_type(ty)
     }
 
-    fn allocatable_registers(&self, func: &ir::Function) -> regalloc::RegisterSet {
-        abi::allocatable_registers(func, &self.triple)
+    fn allocatable_registers(&self, _func: &ir::Function) -> regalloc::RegisterSet {
+        abi::allocatable_registers(&self.triple, &self.shared_flags)
     }
 
     #[cfg(feature = "testing_hooks")]

--- a/cranelift-codegen/src/legalizer/mod.rs
+++ b/cranelift-codegen/src/legalizer/mod.rs
@@ -61,10 +61,7 @@ fn legalize_inst(
         pos.use_srcloc(inst);
 
         let arg = match pos.func.dfg[inst] {
-            ir::InstructionData::Unary {
-                arg,
-                ..
-            } => pos.func.dfg.resolve_aliases(arg),
+            ir::InstructionData::Unary { arg, .. } => pos.func.dfg.resolve_aliases(arg),
             _ => panic!("Expected isplit: {}", pos.func.dfg.display_inst(inst, None)),
         };
 

--- a/cranelift-codegen/src/legalizer/mod.rs
+++ b/cranelift-codegen/src/legalizer/mod.rs
@@ -72,8 +72,11 @@ fn legalize_inst(
         };
 
         match pos.func.dfg.value_def(arg) {
-            ir::ValueDef::Result(inst, num) => {
-                if let ir::InstructionData::Binary { opcode, args, .. } = pos.func.dfg[inst] {
+            ir::ValueDef::Result(inst, _num) => {
+                if let ir::InstructionData::Binary {
+                    opcode, args: _, ..
+                } = pos.func.dfg[inst]
+                {
                     if opcode != ir::Opcode::Iconcat {
                         return LegalizeInstResult::SplitLegalizePending;
                     }
@@ -84,7 +87,7 @@ fn legalize_inst(
                     return LegalizeInstResult::SplitLegalizePending;
                 }
             }
-            ir::ValueDef::Param(ebb, num) => {}
+            ir::ValueDef::Param(_ebb, _num) => {}
         }
 
         let res = pos.func.dfg.inst_results(inst).to_vec();

--- a/cranelift-codegen/src/legalizer/mod.rs
+++ b/cranelift-codegen/src/legalizer/mod.rs
@@ -91,13 +91,9 @@ fn legalize_inst(
         assert_eq!(res.len(), 2);
         let (resl, resh) = (res[0], res[1]); // Prevent borrowck error
 
-        dbg!(pos.position());
-
         // Remove old isplit
         pos.func.dfg.clear_results(inst);
         pos.remove_inst();
-
-        dbg!(pos.position());
 
         let curpos = pos.position();
         let srcloc = pos.srcloc();
@@ -105,8 +101,6 @@ fn legalize_inst(
 
         pos.func.dfg.change_to_alias(resl, xl);
         pos.func.dfg.change_to_alias(resh, xh);
-
-        dbg!(&pos.func);
 
         return LegalizeInstResult::Legalized;
     }

--- a/cranelift-codegen/src/legalizer/mod.rs
+++ b/cranelift-codegen/src/legalizer/mod.rs
@@ -174,6 +174,10 @@ pub fn legalize_function(func: &mut ir::Function, cfg: &mut ControlFlowGraph, is
         }
     }
 
+    while let Some(ebb) = pos.next_ebb() {
+        split::split_ebb_params(pos.func, cfg, ebb);
+    }
+
     // Try legalizing `isplit` and `vsplit` instructions, which could not previously be legalized.
     for inst in pending_splits {
         //pos.goto_inst(inst);

--- a/cranelift-codegen/src/legalizer/mod.rs
+++ b/cranelift-codegen/src/legalizer/mod.rs
@@ -84,7 +84,7 @@ fn legalize_inst(
                     return LegalizeInstResult::SplitLegalizePending;
                 }
             }
-            ir::ValueDef::Param(ebb, num) => {},
+            ir::ValueDef::Param(ebb, num) => {}
         }
 
         let res = pos.func.dfg.inst_results(inst).to_vec();

--- a/cranelift-codegen/src/legalizer/mod.rs
+++ b/cranelift-codegen/src/legalizer/mod.rs
@@ -174,8 +174,8 @@ pub fn legalize_function(func: &mut ir::Function, cfg: &mut ControlFlowGraph, is
 
     // Try legalizing `isplit` and `vsplit` instructions, which could not previously be legalized.
     for inst in pending_splits {
-        //pos.goto_inst(inst);
-        //legalize_inst(inst, &mut pos, cfg, isa);
+        pos.goto_inst(inst);
+        legalize_inst(inst, &mut pos, cfg, isa);
     }
 
     // Now that we've lowered all br_tables, we don't need the jump tables anymore.

--- a/cranelift-codegen/src/legalizer/mod.rs
+++ b/cranelift-codegen/src/legalizer/mod.rs
@@ -588,9 +588,12 @@ fn narrow_load(
         _ => panic!("Expected load: {}", pos.func.dfg.display_inst(inst, None)),
     };
 
-    let al = pos.ins().load(ir::types::I64, flags, ptr, offset);
+    let res_ty = pos.func.dfg.ctrl_typevar(inst);
+    let small_ty = res_ty.half_width().expect("Can't narrow load");
+
+    let al = pos.ins().load(small_ty, flags, ptr, offset);
     let ah = pos.ins().load(
-        ir::types::I64,
+        small_ty,
         flags,
         ptr,
         offset.try_add_i64(8).expect("load offset overflow"),
@@ -618,7 +621,7 @@ fn narrow_store(
         _ => panic!("Expected store: {}", pos.func.dfg.display_inst(inst, None)),
     };
 
-    let (al, ah) = pos.func.dfg.replace(inst).isplit(val);
+    let (al, ah) = pos.ins().isplit(val);
     pos.ins().store(flags, al, ptr, offset);
     pos.ins().store(
         flags,
@@ -626,4 +629,5 @@ fn narrow_store(
         ptr,
         offset.try_add_i64(8).expect("store offset overflow"),
     );
+    pos.remove_inst();
 }

--- a/cranelift-codegen/src/legalizer/split.rs
+++ b/cranelift-codegen/src/legalizer/split.rs
@@ -68,6 +68,7 @@ use crate::cursor::{Cursor, CursorPosition, FuncCursor};
 use crate::flowgraph::{BasicBlock, ControlFlowGraph};
 use crate::ir::{self, Ebb, Inst, InstBuilder, InstructionData, Opcode, Type, Value, ValueDef};
 use core::iter;
+use smallvec::SmallVec;
 use std::vec::Vec;
 
 /// Split `value` into two values using the `isplit` semantics. Do this by reusing existing values
@@ -373,7 +374,7 @@ fn resolve_splits(dfg: &ir::DataFlowGraph, value: Value) -> Value {
 /// After legalizing the instructions computing the value that was split, it is likely that we can
 /// avoid depending on the split instruction. Its input probably comes from a concatenation.
 pub fn simplify_branch_arguments(dfg: &mut ir::DataFlowGraph, branch: Inst) {
-    let mut new_args = Vec::new();
+    let mut new_args = SmallVec::<[Value; 32]>::new();
 
     for &arg in dfg.inst_args(branch) {
         let new_arg = resolve_splits(dfg, arg);

--- a/cranelift-codegen/src/legalizer/split.rs
+++ b/cranelift-codegen/src/legalizer/split.rs
@@ -129,15 +129,18 @@ fn split_any(
     result
 }
 
-pub fn split_ebb_params(
-    func: &mut ir::Function,
-    cfg: &ControlFlowGraph,
-    ebb: Ebb,
-) {
+pub fn split_ebb_params(func: &mut ir::Function, cfg: &ControlFlowGraph, ebb: Ebb) {
     let mut repairs = Vec::new();
     let pos = &mut FuncCursor::new(func).at_top(ebb);
 
-    for (num, ebb_param) in pos.func.dfg.ebb_params(ebb).to_vec().into_iter().enumerate() {
+    for (num, ebb_param) in pos
+        .func
+        .dfg
+        .ebb_params(ebb)
+        .to_vec()
+        .into_iter()
+        .enumerate()
+    {
         let ty = pos.func.dfg.value_type(ebb_param);
         if ty != ir::types::I128 {
             continue;
@@ -149,11 +152,7 @@ pub fn split_ebb_params(
     perform_repairs(pos, cfg, repairs);
 }
 
-fn perform_repairs(
-    pos: &mut FuncCursor,
-    cfg: &ControlFlowGraph,
-    mut repairs: Vec<Repair>,
-) {
+fn perform_repairs(pos: &mut FuncCursor, cfg: &ControlFlowGraph, mut repairs: Vec<Repair>) {
     // We have split the value requested, and now we may need to fix some EBB predecessors.
     while let Some(repair) = repairs.pop() {
         for BasicBlock { inst, .. } in cfg.pred_iter(repair.ebb) {

--- a/cranelift-codegen/src/regalloc/context.rs
+++ b/cranelift-codegen/src/regalloc/context.rs
@@ -198,8 +198,14 @@ impl Context {
         }
 
         // Pass: Coloring.
-        self.coloring
-            .run(isa, func, domtree, &mut self.liveness, &mut self.tracker);
+        self.coloring.run(
+            isa,
+            func,
+            cfg,
+            domtree,
+            &mut self.liveness,
+            &mut self.tracker,
+        );
 
         // This function runs after register allocation has taken
         // place, meaning values have locations assigned already.
@@ -218,7 +224,7 @@ impl Context {
         if isa.flags().enable_verifier() {
             let ok = verify_context(func, cfg, domtree, isa, &mut errors).is_ok()
                 && verify_liveness(isa, func, cfg, &self.liveness, &mut errors).is_ok()
-                && verify_locations(isa, func, Some(&self.liveness), &mut errors).is_ok()
+                && verify_locations(isa, func, cfg, Some(&self.liveness), &mut errors).is_ok()
                 && verify_cssa(
                     func,
                     cfg,

--- a/cranelift-codegen/src/regalloc/register_set.rs
+++ b/cranelift-codegen/src/regalloc/register_set.rs
@@ -268,6 +268,7 @@ mod tests {
         subclasses: 0,
         mask: [0xf0000000, 0x0000000f, 0],
         info: &INFO,
+        pinned_reg: None,
     };
 
     const DPR: RegClass = &RegClassData {
@@ -280,6 +281,7 @@ mod tests {
         subclasses: 0,
         mask: [0x50000000, 0x0000000a, 0],
         info: &INFO,
+        pinned_reg: None,
     };
 
     const INFO: RegInfo = RegInfo {

--- a/cranelift-codegen/src/regalloc/reload.rs
+++ b/cranelift-codegen/src/regalloc/reload.rs
@@ -233,7 +233,7 @@ impl<'a> Context<'a> {
                             let dst_ty = self.cur.func.dfg.value_type(dst_val);
                             debug_assert!(src_ty == dst_ty);
                             // This limits the transformation to copies of the
-                            // types: I64 I32 I16 I8 F64 and F32, since that's
+                            // types: I128 I64 I32 I16 I8 F64 and F32, since that's
                             // the set of `copy_nop` encodings available.
                             src_ty.is_int() || src_ty.is_float()
                         }

--- a/cranelift-codegen/src/regalloc/solver.rs
+++ b/cranelift-codegen/src/regalloc/solver.rs
@@ -877,6 +877,7 @@ impl Solver {
             let d = v.iter(&self.regs_in, &self.regs_out, global_regs).len();
             v.domain = cmp::min(d, u16::MAX as usize) as u16;
         }
+
         // Solve for vars with small domains first to increase the chance of finding a solution.
         //
         // Also consider this case:
@@ -949,9 +950,8 @@ impl Solver {
                     // live registers be diverted. We need to make it a non-global value.
                     if v.is_global && gregs.iter(rc).next().is_none() {
                         return Err(SolverError::Global(v.value));
-                    } else {
-                        return Err(SolverError::Divert(rc));
                     }
+                    return Err(SolverError::Divert(rc));
                 }
             };
 
@@ -976,7 +976,7 @@ impl Solver {
     }
 
     /// Check if `value` can be added as a variable to help find a solution.
-    pub fn can_add_var(&mut self, _value: Value, constraint: RegClass, from: RegUnit) -> bool {
+    pub fn can_add_var(&mut self, constraint: RegClass, from: RegUnit) -> bool {
         !self.regs_in.is_avail(constraint, from)
     }
 }
@@ -1030,7 +1030,7 @@ impl Solver {
         let mut avail = regs.clone();
         let mut i = 0;
         while i < self.moves.len() + self.fills.len() {
-            // Don't even look at the fills until we've spent all the moves. Deferring these let's
+            // Don't even look at the fills until we've spent all the moves. Deferring these lets
             // us potentially reuse the claimed registers to resolve multiple cycles.
             if i >= self.moves.len() {
                 self.moves.append(&mut self.fills);

--- a/cranelift-codegen/src/regalloc/virtregs.rs
+++ b/cranelift-codegen/src/regalloc/virtregs.rs
@@ -21,6 +21,7 @@ use crate::packed_option::PackedOption;
 use crate::ref_slice::ref_slice;
 use core::cmp::Ordering;
 use core::fmt;
+use smallvec::SmallVec;
 use std::vec::Vec;
 
 /// A virtual register reference.
@@ -292,7 +293,7 @@ impl VirtRegs {
     /// Find the leader value and rank of the set containing `v`.
     /// Compress the path if needed.
     fn find(&mut self, mut val: Value) -> (Value, u32) {
-        let mut val_stack = vec![];
+        let mut val_stack = SmallVec::<[Value; 8]>::new();
         let found = loop {
             match UFEntry::decode(self.union_find[val]) {
                 UFEntry::Rank(rank) => break (val, rank),

--- a/cranelift-codegen/src/settings.rs
+++ b/cranelift-codegen/src/settings.rs
@@ -389,6 +389,7 @@ mod tests {
              enable_float = true\n\
              enable_nan_canonicalization = false\n\
              enable_pinned_reg = false\n\
+             use_pinned_reg_as_heap_base = false\n\
              enable_simd = false\n\
              enable_atomics = true\n\
              enable_safepoints = false\n\

--- a/cranelift-codegen/src/settings.rs
+++ b/cranelift-codegen/src/settings.rs
@@ -388,6 +388,7 @@ mod tests {
              avoid_div_traps = false\n\
              enable_float = true\n\
              enable_nan_canonicalization = false\n\
+             enable_pinned_reg = false\n\
              enable_simd = false\n\
              enable_atomics = true\n\
              enable_safepoints = false\n\

--- a/cranelift-codegen/src/verifier/mod.rs
+++ b/cranelift-codegen/src/verifier/mod.rs
@@ -676,6 +676,26 @@ impl<'a> Verifier<'a> {
                 self.verify_value_list(inst, args, errors)?;
             }
 
+            NullAry {
+                opcode: Opcode::GetPinnedReg,
+            }
+            | Unary {
+                opcode: Opcode::SetPinnedReg,
+                ..
+            } => {
+                if let Some(isa) = &self.isa {
+                    if !isa.flags().enable_pinned_reg() {
+                        return fatal!(
+                            errors,
+                            inst,
+                            "GetPinnedReg/SetPinnedReg cannot be used without enable_pinned_reg"
+                        );
+                    }
+                } else {
+                    return fatal!(errors, inst, "GetPinnedReg/SetPinnedReg need an ISA!");
+                }
+            }
+
             // Exhaustive list so we can't forget to add new formats
             Unary { .. }
             | UnaryImm { .. }

--- a/cranelift-entity/Cargo.toml
+++ b/cranelift-entity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-entity"
-version = "0.41.0"
+version = "0.42.0"
 description = "Data structures using entity references as mapping keys"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://cranelift.readthedocs.io/"

--- a/cranelift-faerie/Cargo.toml
+++ b/cranelift-faerie/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-faerie"
-version = "0.41.0"
+version = "0.42.0"
 authors = ["The Cranelift Project Developers"]
 description = "Emit Cranelift output to native object files with Faerie"
 repository = "https://github.com/CraneStation/cranelift"
@@ -10,8 +10,8 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = { path = "../cranelift-codegen", version = "0.41.0" }
-cranelift-module = { path = "../cranelift-module", version = "0.41.0" }
+cranelift-codegen = { path = "../cranelift-codegen", version = "0.42.0" }
+cranelift-module = { path = "../cranelift-module", version = "0.42.0" }
 faerie = "0.11.0"
 goblin = "0.0.24"
 failure = "0.1.2"

--- a/cranelift-faerie/Cargo.toml
+++ b/cranelift-faerie/Cargo.toml
@@ -15,7 +15,7 @@ cranelift-module = { path = "../cranelift-module", version = "0.42.0" }
 faerie = "0.11.0"
 goblin = "0.0.24"
 failure = "0.1.2"
-target-lexicon = "0.8.0"
+target-lexicon = "0.8.1"
 
 [badges]
 maintenance = { status = "experimental" }

--- a/cranelift-filetests/Cargo.toml
+++ b/cranelift-filetests/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-filetests"
 authors = ["The Cranelift Project Developers"]
-version = "0.41.0"
+version = "0.42.0"
 description = "Test driver and implementations of the filetest commands"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://cranelift.readthedocs.io/en/latest/testing.html#file-tests"
@@ -10,10 +10,10 @@ publish = false
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = { path = "../cranelift-codegen", version = "0.41.0", features = ["testing_hooks"] }
-cranelift-native = { path = "../cranelift-native", version = "0.41.0" }
-cranelift-reader = { path = "../cranelift-reader", version = "0.41.0" }
-cranelift-preopt = { path = "../cranelift-preopt", version = "0.41.0" }
+cranelift-codegen = { path = "../cranelift-codegen", version = "0.42.0", features = ["testing_hooks"] }
+cranelift-native = { path = "../cranelift-native", version = "0.42.0" }
+cranelift-reader = { path = "../cranelift-reader", version = "0.42.0" }
+cranelift-preopt = { path = "../cranelift-preopt", version = "0.42.0" }
 file-per-thread-logger = "0.1.2"
 filecheck = "0.4.0"
 log = "0.4.6"

--- a/cranelift-frontend/Cargo.toml
+++ b/cranelift-frontend/Cargo.toml
@@ -15,6 +15,7 @@ cranelift-codegen = { path = "../cranelift-codegen", version = "0.42.0", default
 target-lexicon = "0.8.1"
 log = { version = "0.4.6", default-features = false }
 hashmap_core = { version = "0.1.9", optional = true }
+smallvec = { version = "0.6.10" }
 
 [features]
 default = ["std"]

--- a/cranelift-frontend/Cargo.toml
+++ b/cranelift-frontend/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 cranelift-codegen = { path = "../cranelift-codegen", version = "0.42.0", default-features = false }
-target-lexicon = "0.8.0"
+target-lexicon = "0.8.1"
 log = { version = "0.4.6", default-features = false }
 hashmap_core = { version = "0.1.9", optional = true }
 

--- a/cranelift-frontend/Cargo.toml
+++ b/cranelift-frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-frontend"
-version = "0.41.0"
+version = "0.42.0"
 description = "Cranelift IR builder helper"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://cranelift.readthedocs.io/"
@@ -11,7 +11,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = { path = "../cranelift-codegen", version = "0.41.0", default-features = false }
+cranelift-codegen = { path = "../cranelift-codegen", version = "0.42.0", default-features = false }
 target-lexicon = "0.8.0"
 log = { version = "0.4.6", default-features = false }
 hashmap_core = { version = "0.1.9", optional = true }

--- a/cranelift-frontend/src/lib.rs
+++ b/cranelift-frontend/src/lib.rs
@@ -50,10 +50,12 @@
 //!    jump block1
 //! block1:
 //!    z = z + y;
-//!    brnz y, block2;
+//!    brnz y, block3;
+//!    jump block2
+//! block2:
 //!    z = z - x;
 //!    return y
-//! block2:
+//! block3:
 //!    y = y - x
 //!    jump block1
 //! }
@@ -85,6 +87,7 @@
 //!         let block0 = builder.create_ebb();
 //!         let block1 = builder.create_ebb();
 //!         let block2 = builder.create_ebb();
+//!         let block3 = builder.create_ebb();
 //!         let x = Variable::new(0);
 //!         let y = Variable::new(1);
 //!         let z = Variable::new(2);
@@ -120,8 +123,12 @@
 //!         }
 //!         {
 //!             let arg = builder.use_var(y);
-//!             builder.ins().brnz(arg, block2, &[]);
+//!             builder.ins().brnz(arg, block3, &[]);
 //!         }
+//!         builder.ins().jump(block2, &[]);
+//!
+//!         builder.switch_to_block(block2);
+//!         builder.seal_block(block2);
 //!         {
 //!             let arg1 = builder.use_var(z);
 //!             let arg2 = builder.use_var(x);
@@ -133,8 +140,8 @@
 //!             builder.ins().return_(&[arg]);
 //!         }
 //!
-//!         builder.switch_to_block(block2);
-//!         builder.seal_block(block2);
+//!         builder.switch_to_block(block3);
+//!         builder.seal_block(block3);
 //!
 //!         {
 //!             let arg1 = builder.use_var(y);

--- a/cranelift-frontend/src/lib.rs
+++ b/cranelift-frontend/src/lib.rs
@@ -3,7 +3,7 @@
 //! Provides a straightforward way to create a Cranelift IR function and fill it with instructions
 //! corresponding to your source program written in another language.
 //!
-//! To get started, create an [`FunctionBuilderContext`](struct.FunctionBuilderContext.html) and
+//! To get started, create an [`Function`](../cranelift_codegen/ir/function/struct.Function.html) and
 //! pass it as an argument to a [`FunctionBuilder`](struct.FunctionBuilder.html).
 //!
 //! # Mutable variables and Cranelift IR values
@@ -61,7 +61,7 @@
 //! }
 //! ```
 //!
-//! Here is how you build the corresponding Cranelift IR function using `FunctionBuilderContext`:
+//! Here is how you build the corresponding Cranelift IR function using `Function`:
 //!
 //! ```rust
 //! extern crate cranelift_codegen;
@@ -73,16 +73,15 @@
 //! use cranelift_codegen::isa::CallConv;
 //! use cranelift_codegen::settings;
 //! use cranelift_codegen::verifier::verify_function;
-//! use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext, Variable};
+//! use cranelift_frontend::{FunctionBuilder, Variable};
 //!
 //! fn main() {
 //!     let mut sig = Signature::new(CallConv::SystemV);
 //!     sig.returns.push(AbiParam::new(I32));
 //!     sig.params.push(AbiParam::new(I32));
-//!     let mut fn_builder_ctx = FunctionBuilderContext::new();
-//!     let mut func = Function::with_name_signature(ExternalName::user(0, 0), sig);
-//!     {
-//!         let mut builder = FunctionBuilder::new(&mut func, &mut fn_builder_ctx);
+//!     let func = {
+//!         let func = Function::with_name_signature(ExternalName::user(0, 0), sig);
+//!         let mut builder = FunctionBuilder::new(func);
 //!
 //!         let block0 = builder.create_ebb();
 //!         let block1 = builder.create_ebb();
@@ -152,8 +151,8 @@
 //!         builder.ins().jump(block1, &[]);
 //!         builder.seal_block(block1);
 //!
-//!         builder.finalize();
-//!     }
+//!         builder.finalize()
+//!     };
 //!
 //!     let flags = settings::Flags::new(settings::builder());
 //!     let res = verify_function(&func, &flags);
@@ -195,7 +194,7 @@ use hashmap_core::HashMap;
 #[cfg(feature = "std")]
 use std::collections::HashMap;
 
-pub use crate::frontend::{FunctionBuilder, FunctionBuilderContext};
+pub use crate::frontend::FunctionBuilder;
 pub use crate::switch::Switch;
 pub use crate::variable::Variable;
 

--- a/cranelift-frontend/src/ssa.rs
+++ b/cranelift-frontend/src/ssa.rs
@@ -173,9 +173,7 @@ impl SSABuilder {
         self.variables.clear();
         self.blocks.clear();
         self.ebb_headers.clear();
-        debug_assert!(self.calls.is_empty());
-        debug_assert!(self.results.is_empty());
-        debug_assert!(self.side_effects.is_empty());
+        debug_assert!(self.is_empty());
     }
 
     /// Tests whether an `SSABuilder` is in a cleared state.

--- a/cranelift-frontend/src/variable.rs
+++ b/cranelift-frontend/src/variable.rs
@@ -1,6 +1,6 @@
 //! A basic `Variable` implementation.
 //!
-//! `FunctionBuilderContext`, `FunctionBuilder`, and related types have a `Variable`
+//! `FunctionBuilder` and related types have a `Variable`
 //! type parameter, to allow frontends that identify variables with
 //! their own index types to use them directly. Frontends which don't
 //! can use the `Variable` defined here.

--- a/cranelift-module/Cargo.toml
+++ b/cranelift-module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-module"
-version = "0.41.0"
+version = "0.42.0"
 authors = ["The Cranelift Project Developers"]
 description = "Support for linking functions and data with Cranelift"
 repository = "https://github.com/CraneStation/cranelift"
@@ -11,8 +11,8 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = { path = "../cranelift-codegen", version = "0.41.0", default-features = false }
-cranelift-entity = { path = "../cranelift-entity", version = "0.41.0", default-features = false }
+cranelift-codegen = { path = "../cranelift-codegen", version = "0.42.0", default-features = false }
+cranelift-entity = { path = "../cranelift-entity", version = "0.42.0", default-features = false }
 hashmap_core = { version = "0.1.9", optional = true }
 failure = { version = "0.1.1", default-features = false }
 log = { version = "0.4.6", default-features = false }

--- a/cranelift-native/Cargo.toml
+++ b/cranelift-native/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 cranelift-codegen = { path = "../cranelift-codegen", version = "0.42.0", default-features = false }
-target-lexicon = "0.8.0"
+target-lexicon = "0.8.1"
 
 [target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]
 raw-cpuid = "6.0.0"

--- a/cranelift-native/Cargo.toml
+++ b/cranelift-native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-native"
-version = "0.41.0"
+version = "0.42.0"
 authors = ["The Cranelift Project Developers"]
 description = "Support for targeting the host with Cranelift"
 repository = "https://github.com/CraneStation/cranelift"
@@ -10,7 +10,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = { path = "../cranelift-codegen", version = "0.41.0", default-features = false }
+cranelift-codegen = { path = "../cranelift-codegen", version = "0.42.0", default-features = false }
 target-lexicon = "0.8.0"
 
 [target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]

--- a/cranelift-preopt/Cargo.toml
+++ b/cranelift-preopt/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-preopt"
-version = "0.41.0"
+version = "0.42.0"
 description = "Support for optimizations in Cranelift"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://cranelift.readthedocs.io/"
@@ -12,8 +12,8 @@ keywords = ["optimize", "compile", "compiler", "jit"]
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = { path = "../cranelift-codegen", version = "0.41.0", default-features = false }
-cranelift-entity = { path = "../cranelift-entity", version = "0.41.0", default-features = false }
+cranelift-codegen = { path = "../cranelift-codegen", version = "0.42.0", default-features = false }
+cranelift-entity = { path = "../cranelift-entity", version = "0.42.0", default-features = false }
 # This is commented out because it doesn't build on Rust 1.25.0, which
 # cranelift currently supports.
 # rustc_apfloat = { version = "0.1.2", default-features = false }

--- a/cranelift-reader/Cargo.toml
+++ b/cranelift-reader/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 cranelift-codegen = { path = "../cranelift-codegen", version = "0.42.0" }
-target-lexicon = "0.8.0"
+target-lexicon = "0.8.1"
 
 [badges]
 maintenance = { status = "experimental" }

--- a/cranelift-reader/Cargo.toml
+++ b/cranelift-reader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-reader"
-version = "0.41.0"
+version = "0.42.0"
 description = "Cranelift textual IR reader"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://cranelift.readthedocs.io/"
@@ -10,7 +10,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = { path = "../cranelift-codegen", version = "0.41.0" }
+cranelift-codegen = { path = "../cranelift-codegen", version = "0.42.0" }
 target-lexicon = "0.8.0"
 
 [badges]

--- a/cranelift-reader/src/lexer.rs
+++ b/cranelift-reader/src/lexer.rs
@@ -373,6 +373,7 @@ impl<'a> Lexer<'a> {
             "b16" => types::B16,
             "b32" => types::B32,
             "b64" => types::B64,
+            "b128" => types::B128,
             "r32" => types::R32,
             "r64" => types::R64,
             _ => return None,

--- a/cranelift-reader/src/lexer.rs
+++ b/cranelift-reader/src/lexer.rs
@@ -365,6 +365,7 @@ impl<'a> Lexer<'a> {
             "i16" => types::I16,
             "i32" => types::I32,
             "i64" => types::I64,
+            "i128" => types::I128,
             "f32" => types::F32,
             "f64" => types::F64,
             "b1" => types::B1,

--- a/cranelift-reader/src/parser.rs
+++ b/cranelift-reader/src/parser.rs
@@ -595,7 +595,8 @@ impl<'a> Parser<'a> {
         }
     }
 
-    // Match and consume a Uimm128 immediate; due to size restrictions on InstructionData, Uimm128 is boxed in cranelift-codegen/meta/src/shared/immediates.rs
+    // Match and consume a Uimm128 immediate; due to size restrictions on InstructionData, Uimm128
+    // is boxed in cranelift-codegen/meta/src/shared/immediates.rs
     fn match_uimm128(&mut self, err_msg: &str) -> ParseResult<Uimm128> {
         if let Some(Token::Integer(text)) = self.token() {
             self.consume();

--- a/cranelift-serde/Cargo.toml
+++ b/cranelift-serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-serde"
-version = "0.41.0"
+version = "0.42.0"
 authors = ["The Cranelift Project Developers"]
 description = "Serializer/Deserializer for Cranelift IR"
 repository = "https://github.com/CraneStation/cranelift"
@@ -18,8 +18,8 @@ clap = "2.32.0"
 serde = "1.0.8"
 serde_derive = "1.0.75"
 serde_json = "1.0.26"
-cranelift-codegen = { path = "../cranelift-codegen", version = "0.41.0" }
-cranelift-reader = { path = "../cranelift-reader", version = "0.41.0" }
+cranelift-codegen = { path = "../cranelift-codegen", version = "0.42.0" }
+cranelift-reader = { path = "../cranelift-reader", version = "0.42.0" }
 
 [badges]
 maintenance = { status = "experimental" }

--- a/cranelift-simplejit/Cargo.toml
+++ b/cranelift-simplejit/Cargo.toml
@@ -16,7 +16,7 @@ cranelift-native = { path = "../cranelift-native", version = "0.42.0" }
 region = "2.0.0"
 libc = { version = "0.2.42" }
 errno = "0.2.4"
-target-lexicon = "0.8.0"
+target-lexicon = "0.8.1"
 memmap = { version = "0.7.0", optional = true } 
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/cranelift-simplejit/Cargo.toml
+++ b/cranelift-simplejit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-simplejit"
-version = "0.41.0"
+version = "0.42.0"
 authors = ["The Cranelift Project Developers"]
 description = "A simple JIT library backed by Cranelift"
 repository = "https://github.com/CraneStation/cranelift"
@@ -10,9 +10,9 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = { path = "../cranelift-codegen", version = "0.41.0" }
-cranelift-module = { path = "../cranelift-module", version = "0.41.0" }
-cranelift-native = { path = "../cranelift-native", version = "0.41.0" }
+cranelift-codegen = { path = "../cranelift-codegen", version = "0.42.0" }
+cranelift-module = { path = "../cranelift-module", version = "0.42.0" }
+cranelift-native = { path = "../cranelift-native", version = "0.42.0" }
 region = "2.0.0"
 libc = { version = "0.2.42" }
 errno = "0.2.4"
@@ -27,9 +27,9 @@ selinux-fix = ['memmap']
 default = []
 
 [dev-dependencies]
-cranelift = { path = "../cranelift-umbrella", version = "0.41.0" }
-cranelift-frontend = { path = "../cranelift-frontend", version = "0.41.0" }
-cranelift-entity = { path = "../cranelift-entity", version = "0.41.0" }
+cranelift = { path = "../cranelift-umbrella", version = "0.42.0" }
+cranelift-frontend = { path = "../cranelift-frontend", version = "0.42.0" }
+cranelift-entity = { path = "../cranelift-entity", version = "0.42.0" }
 
 [badges]
 maintenance = { status = "experimental" }

--- a/cranelift-simplejit/examples/simplejit-minimal.rs
+++ b/cranelift-simplejit/examples/simplejit-minimal.rs
@@ -7,7 +7,6 @@ fn main() {
     let mut module: Module<SimpleJITBackend> =
         Module::new(SimpleJITBuilder::new(default_libcall_names()));
     let mut ctx = module.make_context();
-    let mut func_ctx = FunctionBuilderContext::new();
 
     let mut sig_a = module.make_signature();
     sig_a.params.push(AbiParam::new(types::I32));
@@ -25,8 +24,8 @@ fn main() {
 
     ctx.func.signature = sig_a;
     ctx.func.name = ExternalName::user(0, func_a.as_u32());
-    {
-        let mut bcx: FunctionBuilder = FunctionBuilder::new(&mut ctx.func, &mut func_ctx);
+    ctx.func = {
+        let mut bcx: FunctionBuilder = FunctionBuilder::new(ctx.func);
         let ebb = bcx.create_ebb();
 
         bcx.switch_to_block(ebb);
@@ -36,15 +35,15 @@ fn main() {
         let add = bcx.ins().iadd(cst, param);
         bcx.ins().return_(&[add]);
         bcx.seal_all_blocks();
-        bcx.finalize();
-    }
+        bcx.finalize()
+    };
     module.define_function(func_a, &mut ctx).unwrap();
     module.clear_context(&mut ctx);
 
     ctx.func.signature = sig_b;
     ctx.func.name = ExternalName::user(0, func_b.as_u32());
-    {
-        let mut bcx: FunctionBuilder = FunctionBuilder::new(&mut ctx.func, &mut func_ctx);
+    ctx.func = {
+        let mut bcx: FunctionBuilder = FunctionBuilder::new(ctx.func);
         let ebb = bcx.create_ebb();
 
         bcx.switch_to_block(ebb);
@@ -58,8 +57,8 @@ fn main() {
         };
         bcx.ins().return_(&[value]);
         bcx.seal_all_blocks();
-        bcx.finalize();
-    }
+        bcx.finalize()
+    };
     module.define_function(func_b, &mut ctx).unwrap();
     module.clear_context(&mut ctx);
 

--- a/cranelift-umbrella/Cargo.toml
+++ b/cranelift-umbrella/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift"
-version = "0.41.0"
+version = "0.42.0"
 description = "Umbrella for commonly-used cranelift crates"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://cranelift.readthedocs.io/"
@@ -12,8 +12,8 @@ keywords = ["compile", "compiler", "jit"]
 edition = "2018"
 
 [dependencies]
-cranelift-codegen = { path = "../cranelift-codegen", version = "0.41.0", default-features = false }
-cranelift-frontend = { path = "../cranelift-frontend", version = "0.41.0", default-features = false }
+cranelift-codegen = { path = "../cranelift-codegen", version = "0.42.0", default-features = false }
+cranelift-frontend = { path = "../cranelift-frontend", version = "0.42.0", default-features = false }
 
 [features]
 default = ["std"]

--- a/cranelift-umbrella/src/lib.rs
+++ b/cranelift-umbrella/src/lib.rs
@@ -43,7 +43,7 @@ pub mod prelude {
     pub use crate::codegen::isa;
     pub use crate::codegen::settings::{self, Configurable};
 
-    pub use crate::frontend::{FunctionBuilder, FunctionBuilderContext, Variable};
+    pub use crate::frontend::{FunctionBuilder, Variable};
 }
 
 /// Version number of this crate.

--- a/cranelift-wasm/Cargo.toml
+++ b/cranelift-wasm/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1.0.94", features = ["derive"], optional = true }
 
 [dev-dependencies]
 wabt = "0.9.1"
-target-lexicon = "0.8.0"
+target-lexicon = "0.8.1"
 
 [features]
 default = ["std"]

--- a/cranelift-wasm/Cargo.toml
+++ b/cranelift-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-wasm"
-version = "0.41.0"
+version = "0.42.0"
 authors = ["The Cranelift Project Developers"]
 description = "Translator from WebAssembly to Cranelift IR"
 repository = "https://github.com/CraneStation/cranelift"
@@ -12,9 +12,9 @@ edition = "2018"
 
 [dependencies]
 wasmparser = { version = "0.37.0", default-features = false }
-cranelift-codegen = { path = "../cranelift-codegen", version = "0.41.0", default-features = false }
-cranelift-entity = { path = "../cranelift-entity", version = "0.41.0", default-features = false }
-cranelift-frontend = { path = "../cranelift-frontend", version = "0.41.0", default-features = false }
+cranelift-codegen = { path = "../cranelift-codegen", version = "0.42.0", default-features = false }
+cranelift-entity = { path = "../cranelift-entity", version = "0.42.0", default-features = false }
+cranelift-frontend = { path = "../cranelift-frontend", version = "0.42.0", default-features = false }
 hashmap_core = { version = "0.1.9", optional = true }
 failure = { version = "0.1.1", default-features = false, features = ["derive"] }
 failure_derive = { version = "0.1.1", default-features = false }

--- a/cranelift-wasm/src/code_translator.rs
+++ b/cranelift-wasm/src/code_translator.rs
@@ -81,7 +81,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
          *  `get_global` and `set_global` are handled by the environment.
          ***********************************************************************************/
         Operator::GetGlobal { global_index } => {
-            let val = match state.get_global(builder.func, *global_index, environ)? {
+            let val = match state.get_global(&mut builder.func, *global_index, environ)? {
                 GlobalVariable::Const(val) => val,
                 GlobalVariable::Memory { gv, offset, ty } => {
                     let addr = builder.ins().global_value(environ.pointer_type(), gv);
@@ -92,7 +92,7 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             state.push1(val);
         }
         Operator::SetGlobal { global_index } => {
-            match state.get_global(builder.func, *global_index, environ)? {
+            match state.get_global(&mut builder.func, *global_index, environ)? {
                 GlobalVariable::Const(_) => panic!("global #{} is a constant", *global_index),
                 GlobalVariable::Memory { gv, offset, ty } => {
                     let addr = builder.ins().global_value(environ.pointer_type(), gv);
@@ -367,7 +367,8 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
          * argument referring to an index in the external functions table of the module.
          ************************************************************************************/
         Operator::Call { function_index } => {
-            let (fref, num_args) = state.get_direct_func(builder.func, *function_index, environ)?;
+            let (fref, num_args) =
+                state.get_direct_func(&mut builder.func, *function_index, environ)?;
             let call = environ.translate_call(
                 builder.cursor(),
                 FuncIndex::from_u32(*function_index),
@@ -388,8 +389,8 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
         Operator::CallIndirect { index, table_index } => {
             // `index` is the index of the function's signature and `table_index` is the index of
             // the table to search the function in.
-            let (sigref, num_args) = state.get_indirect_sig(builder.func, *index, environ)?;
-            let table = state.get_table(builder.func, *table_index, environ)?;
+            let (sigref, num_args) = state.get_indirect_sig(&mut builder.func, *index, environ)?;
+            let table = state.get_table(&mut builder.func, *table_index, environ)?;
             let callee = state.pop1();
             let call = environ.translate_call_indirect(
                 builder.cursor(),
@@ -417,13 +418,13 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             // The WebAssembly MVP only supports one linear memory, but we expect the reserved
             // argument to be a memory index.
             let heap_index = MemoryIndex::from_u32(*reserved);
-            let heap = state.get_heap(builder.func, *reserved, environ)?;
+            let heap = state.get_heap(&mut builder.func, *reserved, environ)?;
             let val = state.pop1();
             state.push1(environ.translate_memory_grow(builder.cursor(), heap_index, heap, val)?)
         }
         Operator::MemorySize { reserved } => {
             let heap_index = MemoryIndex::from_u32(*reserved);
-            let heap = state.get_heap(builder.func, *reserved, environ)?;
+            let heap = state.get_heap(&mut builder.func, *reserved, environ)?;
             state.push1(environ.translate_memory_size(builder.cursor(), heap_index, heap)?);
         }
         /******************************* Load instructions ***********************************
@@ -1231,7 +1232,7 @@ fn translate_load<FE: FuncEnvironment + ?Sized>(
 ) -> WasmResult<()> {
     let addr32 = state.pop1();
     // We don't yet support multiple linear memories.
-    let heap = state.get_heap(builder.func, 0, environ)?;
+    let heap = state.get_heap(&mut builder.func, 0, environ)?;
     let (base, offset) = get_heap_addr(heap, addr32, offset, environ.pointer_type(), builder);
     // Note that we don't set `is_aligned` here, even if the load instruction's
     // alignment immediate says it's aligned, because WebAssembly's immediate
@@ -1256,7 +1257,7 @@ fn translate_store<FE: FuncEnvironment + ?Sized>(
     let val_ty = builder.func.dfg.value_type(val);
 
     // We don't yet support multiple linear memories.
-    let heap = state.get_heap(builder.func, 0, environ)?;
+    let heap = state.get_heap(&mut builder.func, 0, environ)?;
     let (base, offset) = get_heap_addr(heap, addr32, offset, environ.pointer_type(), builder);
     // See the comments in `translate_load` about the flags.
     let flags = MemFlags::new();

--- a/cranelift-wasm/src/environ/dummy.rs
+++ b/cranelift-wasm/src/environ/dummy.rs
@@ -533,8 +533,7 @@ impl<'data> ModuleEnvironment<'data> for DummyEnvironment {
                 func.collect_debug_info();
             }
             self.trans
-                .translate(body_bytes, body_offset, &mut func, &mut func_environ)?;
-            func
+                .translate(body_bytes, body_offset, func, &mut func_environ)?
         };
         self.func_bytecode_sizes.push(body_bytes.len());
         self.info.function_bodies.push(func);

--- a/cranelift-wasm/src/environ/spec.rs
+++ b/cranelift-wasm/src/environ/spec.rs
@@ -469,11 +469,7 @@ pub trait ModuleEnvironment<'data> {
     ) -> WasmResult<()>;
 
     /// Indicates that a custom section has been found in the wasm file
-    fn custom_section(
-        &mut self,
-        name: &'data str,
-        data: &'data [u8],
-    ) -> WasmResult<()> {
+    fn custom_section(&mut self, name: &'data str, data: &'data [u8]) -> WasmResult<()> {
         drop((name, data));
         Ok(())
     }

--- a/cranelift-wasm/src/environ/spec.rs
+++ b/cranelift-wasm/src/environ/spec.rs
@@ -467,4 +467,14 @@ pub trait ModuleEnvironment<'data> {
         offset: usize,
         data: &'data [u8],
     ) -> WasmResult<()>;
+
+    /// Indicates that a custom section has been found in the wasm file
+    fn custom_section(
+        &mut self,
+        name: &'data str,
+        data: &'data [u8],
+    ) -> WasmResult<()> {
+        drop((name, data));
+        Ok(())
+    }
 }

--- a/filetests/isa/riscv/expand-i32.clif.bak
+++ b/filetests/isa/riscv/expand-i32.clif.bak
@@ -1,3 +1,6 @@
+; TODO(ryzokuken): figure out a better legalization strategy for platforms that
+; platforms that don't have flags.
+
 ; Test the legalization of i32 instructions that don't have RISC-V versions.
 test legalizer
 

--- a/filetests/isa/riscv/legalize-i64.clif.bak
+++ b/filetests/isa/riscv/legalize-i64.clif.bak
@@ -1,3 +1,6 @@
+; TODO(ryzokuken): figure out a better legalization strategy for platforms that
+; platforms that don't have flags.
+
 ; Test the legalization of i64 arithmetic instructions.
 test legalizer
 target riscv32 supports_m=1

--- a/filetests/isa/x86/binary32.clif
+++ b/filetests/isa/x86/binary32.clif
@@ -477,6 +477,14 @@ ebb0:
     ; asm: adcl %esi, %ecx
     [-,%rcx,%rflags] v704, v705 = iadd_carry v1, v2, v702 ; bin: 11 f1
 
+    ; Borrow Subtraction
+    ; asm: subl %esi, %ecx
+    [-,%rcx,%rflags] v706, v707 = isub_bout v1, v2         ; bin: 29 f1
+    ; asm: sbbl %esi, %ecx
+    [-,%rcx] v708 = isub_bin v1, v2, v707                  ; bin: 19 f1
+    ; asm: sbbl %esi, %ecx
+    [-,%rcx,%rflags] v709, v710 = isub_borrow v1, v2, v707 ; bin: 19 f1
+
     ; asm: testl %ecx, %ecx
     ; asm: je ebb1
     brz v1, ebb1                                ; bin: 85 c9 74 0e

--- a/filetests/isa/x86/binary32.clif
+++ b/filetests/isa/x86/binary32.clif
@@ -469,6 +469,14 @@ ebb0:
     ; asm: mov    %cl,(%eax,%ebx,1)
     istore8_complex v601, v521+v522      ; bin: heap_oob 88 0c 18
 
+    ; Carry Addition
+    ; asm: addl %esi, %ecx
+    [-,%rcx,%rflags] v701, v702 = iadd_cout v1, v2  ; bin: 01 f1
+    ; asm: adcl %esi, %ecx
+    [-,%rcx] v703 = iadd_cin v1, v2, v702           ; bin: 11 f1
+    ; asm: adcl %esi, %ecx
+    [-,%rcx,%rflags] v704, v705 = iadd_carry v1, v2, v702 ; bin: 11 f1
+
     ; asm: testl %ecx, %ecx
     ; asm: je ebb1
     brz v1, ebb1                                ; bin: 85 c9 74 0e

--- a/filetests/isa/x86/binary64.clif
+++ b/filetests/isa/x86/binary64.clif
@@ -746,11 +746,14 @@ ebb7:
 
     ; asm: ebb1:
 ebb1:
-    return                                       ; bin: c3
+    return                                      ; bin: c3
 
     ; asm: ebb2:
 ebb2:
-    jump ebb1                                   ; bin: eb fd
+    ; Add a no-op instruction to prevent fold_redundant_jump from removing this block.
+    ; asm: notq %rcx
+    [-,%rcx]             v5000 = bnot v1        ; bin: 48 f7 d1
+    jump ebb1                                   ; bin: eb fa
 }
 
 ; CPU flag instructions.
@@ -1349,11 +1352,14 @@ ebb7:
 
     ; asm: ebb1x:
 ebb1:
-    return                                       ; bin: c3
+    return                                      ; bin: c3
 
     ; asm: ebb2x:
 ebb2:
-    jump ebb1                                   ; bin: eb fd
+    ; Add a no-op instruction to prevent fold_redundant_jump from removing this block.
+    ; asm: notl %ecx
+    [-,%rcx]             v5000 = bnot v1        ; bin: f7 d1
+    jump ebb1                                   ; bin: eb fb
 
 }
 

--- a/filetests/isa/x86/br-i128.clif
+++ b/filetests/isa/x86/br-i128.clif
@@ -1,0 +1,24 @@
+test compile
+target x86_64
+
+function u0:0(i128) -> i8 fast {
+ebb0(v0: i128):
+    brz v0, ebb1
+    v1 = iconst.i8 0
+    return v1
+
+ebb1:
+    v2 = iconst.i8 1
+    return v2
+}
+
+function u0:1(i128) -> i8 fast {
+ebb0(v0: i128):
+    brnz v0, ebb1
+    v1 = iconst.i8 0
+    return v1
+
+ebb1:
+    v2 = iconst.i8 1
+    return v2
+}

--- a/filetests/isa/x86/i128.clif
+++ b/filetests/isa/x86/i128.clif
@@ -28,19 +28,19 @@ ebb0(v0: i128):
 }
 
 function u0:2(i64, i128) fast {
-; check: ebb0(v0: i64 [%rdi], v2: i64 [%rsi], v3: i64 [%rdx], v4: i64 [%rbp]):
+; check: ebb0(v0: i64 [%rdi], v2: i64 [%rsi], v3: i64 [%rdx], v6: i64 [%rbp]):
 ebb0(v0: i64, v1: i128):
-    ; check: store v2, v0
-    ; check: store v3, v0+8
-    store v1, v0
+    ; check: store v2, v0+8
+    ; check: store v3, v0+16
+    store v1, v0+8
     return
 }
 
 function u0:3(i64) -> i128 fast {
 ebb0(v0: i64):
-    ; check: v2 = load.i64 v0
-    ; check: v3 = load.i64 v0+8
-    v1 = load.i128 v0
+    ; check: v2 = load.i64 v0+8
+    ; check: v3 = load.i64 v0+16
+    v1 = load.i128 v0+8
     ; check: return v2, v3, v5
     return v1
 }

--- a/filetests/isa/x86/i128.clif
+++ b/filetests/isa/x86/i128.clif
@@ -5,9 +5,9 @@ function u0:0(i128) -> i128 fast {
 ebb0(v0: i128):
     v1 = iconst.i64 0
     v2 = iconst.i64 42
-    v3 = iconcat.i64 v1, v2
+    v3 = iconcat.i64 v2, v1
     return v3
     ; check: v1 = iconst.i64 0
     ; check: v2 = iconst.i64 42
-    ; check: return v1, v2, v7
+    ; check: return v2, v1, v7
 }

--- a/filetests/isa/x86/i128.clif
+++ b/filetests/isa/x86/i128.clif
@@ -1,0 +1,13 @@
+test compile
+target x86_64
+
+function u0:0(i128) -> i128 fast {
+ebb0(v0: i128):
+    v1 = iconst.i64 0
+    v2 = iconst.i64 42
+    v3 = iconcat.i64 v1, v2
+    return v3
+    ; check: v1 = iconst.i64 0
+    ; check: v2 = iconst.i64 42
+    ; check: return v1, v2, v7
+}

--- a/filetests/isa/x86/i128.clif
+++ b/filetests/isa/x86/i128.clif
@@ -1,13 +1,28 @@
 test compile
 target x86_64
 
-function u0:0(i128) -> i128 fast {
+function u0:0(i64, i64) -> i128 fast {
+ebb0(v0: i64, v1: i64):
+;check: ebb0(v0: i64 [%rdi], v1: i64 [%rsi], v3: i64 [%rbp]):
+
+    v2 = iconcat.i64 v0, v1
+    ; check: regmove v0, %rdi -> %rax
+    ; check: regmove v1, %rsi -> %rdx
+
+    return v2
+    ; check: v4 = x86_pop.i64
+    ; check: return v0, v1, v4
+}
+
+function u0:1(i128) -> i64, i64 fast {
 ebb0(v0: i128):
-    v1 = iconst.i64 0
-    v2 = iconst.i64 42
-    v3 = iconcat.i64 v2, v1
-    return v3
-    ; check: v1 = iconst.i64 0
-    ; check: v2 = iconst.i64 42
-    ; check: return v2, v1, v7
+; check: ebb0(v3: i64 [%rdi], v4: i64 [%rsi], v5: i64 [%rbp]):
+
+    v1, v2 = isplit v0
+    ; check: regmove v3, %rdi -> %rax
+    ; check: regmove v4, %rsi -> %rdx
+
+    return v1, v2
+    ; check: v6 = x86_pop.i64
+    ; check: return v3, v4, v6
 }

--- a/filetests/isa/x86/i128.clif
+++ b/filetests/isa/x86/i128.clif
@@ -27,7 +27,7 @@ ebb0(v0: i128):
     ; check: return v3, v4, v6
 }
 
-function u0:1(i64, i128) fast {
+function u0:2(i64, i128) fast {
 ; check: ebb0(v0: i64 [%rdi], v2: i64 [%rsi], v3: i64 [%rdx], v4: i64 [%rbp]):
 ebb0(v0: i64, v1: i128):
     ; check: store v2, v0
@@ -36,7 +36,7 @@ ebb0(v0: i64, v1: i128):
     return
 }
 
-function u0:1(i64) -> i128 fast {
+function u0:3(i64) -> i128 fast {
 ebb0(v0: i64):
     ; check: v2 = load.i64 v0
     ; check: v3 = load.i64 v0+8

--- a/filetests/isa/x86/i128.clif
+++ b/filetests/isa/x86/i128.clif
@@ -26,3 +26,21 @@ ebb0(v0: i128):
     ; check: v6 = x86_pop.i64
     ; check: return v3, v4, v6
 }
+
+function u0:1(i64, i128) fast {
+; check: ebb0(v0: i64 [%rdi], v2: i64 [%rsi], v3: i64 [%rdx], v4: i64 [%rbp]):
+ebb0(v0: i64, v1: i128):
+    ; check: store v2, v0
+    ; check: store v3, v0+8
+    store v1, v0
+    return
+}
+
+function u0:1(i64) -> i128 fast {
+ebb0(v0: i64):
+    ; check: v2 = load.i64 v0
+    ; check: v3 = load.i64 v0+8
+    v1 = load.i128 v0
+    ; check: return v2, v3, v5
+    return v1
+}

--- a/filetests/isa/x86/isplit-not-legalized-twice.clif
+++ b/filetests/isa/x86/isplit-not-legalized-twice.clif
@@ -1,0 +1,20 @@
+test compile
+target x86_64
+
+function u0:0(i64, i64) -> i128 system_v {
+ebb0(v0: i64, v1: i64):
+    trap user0
+
+ebb30:
+    v245 = iconst.i64 0
+    v246 = iconcat v245, v245
+    ; The next instruction used to be legalized twice, causing a panic the second time.
+    v250, v251 = isplit.i128 v370
+    v252, v253 = isplit v246
+    trap user0
+
+ebb45:
+    v369 = iconst.i64 0
+    v370 = load.i128 v369
+    trap user0
+}

--- a/filetests/isa/x86/jump_i128_param_unused.clif
+++ b/filetests/isa/x86/jump_i128_param_unused.clif
@@ -1,0 +1,10 @@
+test compile
+target x86_64
+
+function u0:0(i128) system_v {
+ebb0(v0: i128):
+    jump ebb1(v0)
+
+ebb1(v1: i128):
+    return
+}

--- a/filetests/isa/x86/legalize-br-table-bb.clif
+++ b/filetests/isa/x86/legalize-br-table-bb.clif
@@ -1,6 +1,6 @@
 test compile
 target x86_64
-feature !"basic-blocks"
+feature "basic-blocks"
 ; regex: V=v\d+
 ; regex: EBB=ebb\d+
 
@@ -13,7 +13,8 @@ ebb0(v0: i64):
     v2 = load.i8 v1
     br_table v2, ebb2, jt0
 ; check:     $(oob=$V) = ifcmp_imm $(idx=$V), 1
-; nextln:    brif uge $oob, ebb2
+; ebb2 is replaced by ebb1 by fold_redundant_jump
+; nextln:    brif uge $oob, ebb1
 ; nextln:    fallthrough $(inb=$EBB)
 ; check:   $inb:
 ; nextln:    $(final_idx=$V) = uextend.i64 $idx

--- a/filetests/isa/x86/legalize-br-table.clif
+++ b/filetests/isa/x86/legalize-br-table.clif
@@ -1,6 +1,7 @@
 test compile
 
 target x86_64
+feature !"basic-blocks"
 ; regex: V=v\d+
 ; regex: EBB=ebb\d+
 

--- a/filetests/isa/x86/legalize-i64.clif
+++ b/filetests/isa/x86/legalize-i64.clif
@@ -8,9 +8,20 @@ function %iadd(i64, i64) -> i64 {
 ebb0(v1: i64, v2: i64):
     v10 = iadd v1, v2
     ; check: v1 = iconcat $(v1_lsb=$V), $(v1_msb=$V)
-    ; check: v2 = iconcat $(v2_lsb=$V), $(v2_msb=$V)
-    ; check: $(v10_lsb=$V), $(carry=$V) = iadd_cout $v1_lsb, $v2_lsb
-    ; check: $(v10_msb=$V) = iadd_cin $v1_msb, $v2_msb, $carry
-    ; check: v10 = iconcat $v10_lsb, $v10_msb
+    ; nextln: v2 = iconcat $(v2_lsb=$V), $(v2_msb=$V)
+    ; nextln: $(v10_lsb=$V), $(carry=$V) = iadd_cout $v1_lsb, $v2_lsb
+    ; nextln: $(v10_msb=$V) = iadd_cin $v1_msb, $v2_msb, $carry
+    ; nextln: v10 = iconcat $v10_lsb, $v10_msb
+    return v10
+}
+
+function %isub(i64, i64) -> i64 {
+ebb0(v1: i64, v2: i64):
+    v10 = isub v1, v2
+    ; check: v1 = iconcat $(v1_lsb=$V), $(v1_msb=$V)
+    ; nextln: v2 = iconcat $(v2_lsb=$V), $(v2_msb=$V)
+    ; nextln: $(v10_lsb=$V), $(borrow=$V) = isub_bout $v1_lsb, $v2_lsb
+    ; nextln: $(v10_msb=$V) = isub_bin $v1_msb, $v2_msb, $borrow
+    ; nextln: v10 = iconcat $v10_lsb, $v10_msb
     return v10
 }

--- a/filetests/isa/x86/legalize-i64.clif
+++ b/filetests/isa/x86/legalize-i64.clif
@@ -1,0 +1,16 @@
+; Test the legalization of i64 instructions on x86_32.
+test legalizer
+target i686 haswell
+
+; regex: V=v\d+
+
+function %iadd(i64, i64) -> i64 {
+ebb0(v1: i64, v2: i64):
+    v10 = iadd v1, v2
+    ; check: v1 = iconcat $(v1_lsb=$V), $(v1_msb=$V)
+    ; check: v2 = iconcat $(v2_lsb=$V), $(v2_msb=$V)
+    ; check: $(v10_lsb=$V), $(carry=$V) = iadd_cout $v1_lsb, $v2_lsb
+    ; check: $(v10_msb=$V) = iadd_cin $v1_msb, $v2_msb, $carry
+    ; check: v10 = iconcat $v10_lsb, $v10_msb
+    return v10
+}

--- a/filetests/isa/x86/legalize-isplit-backwards.clif
+++ b/filetests/isa/x86/legalize-isplit-backwards.clif
@@ -1,0 +1,24 @@
+test compile
+target x86_64
+
+function u0:0(i128) -> i64, i64 fast {
+; check: ebb0(v4: i64 [%rdi], v5: i64 [%rsi], v8: i64 [%rbp]):
+ebb0(v0: i128):
+    jump ebb2
+
+ebb1:
+    ; When this `isplit` is legalized, the bnot below is not yet legalized,
+    ; so there isn't a corresponding `iconcat` yet. We should try legalization
+    ; for this `isplit` again once all instrucions have been legalized.
+    v2, v3 = isplit.i128 v1
+    ; return v6, v7
+    return v2, v3
+
+ebb2:
+    ; check: v6 = bnot.i64 v4
+    ; check: v2 -> v6
+    ; check: v7 = bnot.i64 v5
+    ; check: v3 -> v7
+    v1 = bnot.i128 v0
+    jump ebb1
+}

--- a/filetests/isa/x86/load-store-narrow.clif
+++ b/filetests/isa/x86/load-store-narrow.clif
@@ -1,0 +1,16 @@
+test compile
+target i686
+
+function u0:0(i64, i32) system_v {
+ebb0(v0: i64, v1: i32):
+    v2 = bor v0, v0
+    store v2, v1
+    return
+}
+
+function u0:1(i32) -> i64 system_v {
+ebb0(v1: i32):
+    v0 = load.i64 v1
+    v2 = bor v0, v0
+    return v2
+}

--- a/filetests/isa/x86/pinned-reg.clif
+++ b/filetests/isa/x86/pinned-reg.clif
@@ -1,0 +1,74 @@
+test compile
+
+set enable_pinned_reg=true
+set use_pinned_reg_as_heap_base=true
+set opt_level=best
+
+target x86_64
+
+; regex: V=v\d+
+
+; r15 is the pinned heap register. It must not be rewritten, so it must not be
+; used as a tied output register.
+function %tied_input() -> i64 system_v {
+ebb0:
+    v1 = get_pinned_reg.i64
+    v2 = iadd_imm v1, 42
+    return v2
+}
+
+; check: ,%r15]
+; sameln: v1 = get_pinned_reg.i64
+; nextln: regmove v1, %r15 -> %rax
+; nextln: ,%rax]
+; sameln: iadd_imm v1, 42
+
+;; It musn't be used even if this is a tied input used twice.
+function %tied_twice() -> i64 system_v {
+ebb0:
+    v1 = get_pinned_reg.i64
+    v2 = iadd v1, v1
+    return v2
+}
+
+; check: ,%r15]
+; sameln: v1 = get_pinned_reg.i64
+; nextln: regmove v1, %r15 -> %rax
+; nextln: ,%rax]
+; sameln: iadd v1, v1
+
+function %uses() -> i64 system_v {
+ebb0:
+    v1 = get_pinned_reg.i64
+    v2 = iadd_imm v1, 42
+    v3 = get_pinned_reg.i64
+    v4 = iadd v2, v3
+    return v4
+}
+
+; check: ,%r15]
+; sameln: v1 = get_pinned_reg.i64
+; nextln: regmove v1, %r15 -> %rax
+; nextln: ,%rax]
+; sameln: iadd_imm v1, 42
+; nextln: ,%r15
+; sameln: v3 = get_pinned_reg.i64
+; nextln: ,%rax]
+; sameln: iadd v2, v3
+
+; When the pinned register is used as the heap base, the final load instruction
+; must use the %r15 register, since x86 implements the complex addressing mode.
+function u0:1(i64 vmctx) -> i64 system_v {
+    gv0 = vmctx
+    heap0 = static gv0, min 0x000a_0000, bound 0x0001_0000_0000, offset_guard 0x8000_0000, index_type i32
+
+ebb0(v42: i64):
+    v5 = iconst.i32 42
+    v6 = heap_addr.i64 heap0, v5, 0
+    v7 = load.i64 v6
+    return v7
+}
+
+; check: ,%r15]
+; sameln: $(heap_base=$V) = get_pinned_reg.i64
+; nextln: load_complex.i64 $heap_base+

--- a/filetests/safepoint/basic.clif
+++ b/filetests/safepoint/basic.clif
@@ -1,7 +1,7 @@
 test safepoint
-
 set enable_safepoints=true
 target x86_64
+feature !"basic-blocks"
 
 function %test(i32, r64, r64) -> r64 {
     ebb0(v0: i32, v1:r64, v2:r64):

--- a/filetests/safepoint/call.clif
+++ b/filetests/safepoint/call.clif
@@ -1,7 +1,7 @@
 test safepoint
-
 set enable_safepoints=true
 target x86_64
+feature !"basic-blocks"
 
 function %direct() -> r64 {
     fn0 = %none()

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -15,7 +15,7 @@ libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer-sys.git" }
 cranelift-codegen = { path = "../cranelift-codegen" }
 cranelift-wasm = { path = "../cranelift-wasm" }
 cranelift-reader = { path = "../cranelift-reader" }
-target-lexicon = "0.8.0"
+target-lexicon = "0.8.1"
 
 # Prevent this from interfering with workspaces
 [workspace]

--- a/publish-all.sh
+++ b/publish-all.sh
@@ -9,7 +9,7 @@ topdir=$(dirname "$0")
 cd "$topdir"
 
 # All the cranelift-* crates have the same version number
-version="0.41.0"
+version="0.42.0"
 
 # Update all of the Cargo.toml files.
 #

--- a/src/bugpoint_test.clif
+++ b/src/bugpoint_test.clif
@@ -554,6 +554,9 @@ ebb18:
     v196 = load.i8 v195
     v197 = uextend.i32 v196
     brz v197, ebb19
+    jump ebb164
+
+ebb164:
     v198 = global_value.i64 gv12
     trap user0
 
@@ -572,6 +575,9 @@ ebb19:
     v209 = load.i8 v208
     v210 = uextend.i32 v209
     brz v210, ebb20
+    jump ebb163
+
+ebb163:
     v211 = global_value.i64 gv13
     trap user0
 
@@ -605,6 +611,9 @@ ebb22:
     v233 = load.i8 v232
     v234 = uextend.i32 v233
     brz v234, ebb23
+    jump ebb162
+
+ebb162:
     v235 = global_value.i64 gv16
     trap user0
 
@@ -630,6 +639,9 @@ ebb24:
     v252 = load.i8 v251
     v253 = uextend.i32 v252
     brz v253, ebb25
+    jump ebb161
+
+ebb161:
     v254 = global_value.i64 gv17
     trap user0
 
@@ -666,6 +678,9 @@ ebb27:
     v278 = load.i8 v277
     v279 = uextend.i32 v278
     brz v279, ebb28
+    jump ebb160
+
+ebb160:
     v280 = global_value.i64 gv18
     trap user0
 
@@ -681,6 +696,9 @@ ebb28:
     v289 = load.i8 v288
     v290 = uextend.i32 v289
     brz v290, ebb29
+    jump ebb159
+
+ebb159:
     v291 = global_value.i64 gv19
     trap user0
 
@@ -699,6 +717,9 @@ ebb29:
     v302 = load.i8 v301
     v303 = uextend.i32 v302
     brz v303, ebb30
+    jump ebb158
+
+ebb158:
     v304 = global_value.i64 gv20
     trap user0
 
@@ -714,6 +735,9 @@ ebb30:
     v313 = load.i8 v312
     v314 = uextend.i32 v313
     brz v314, ebb31
+    jump ebb157
+
+ebb157:
     v315 = global_value.i64 gv21
     trap user0
 
@@ -887,6 +911,9 @@ ebb49(v1006: i16):
     v411 = load.i8 v410
     v412 = uextend.i32 v411
     brz v412, ebb50
+    jump ebb156
+
+ebb156:
     v413 = global_value.i64 gv28
     trap user0
 
@@ -908,6 +935,9 @@ ebb50:
     v424 = load.i8 v423
     v425 = uextend.i32 v424
     brz v425, ebb51
+    jump ebb155
+
+ebb155:
     v426 = global_value.i64 gv29
     trap user0
 
@@ -922,6 +952,9 @@ ebb51:
     v432 = bint.i8 v431
     v433 = uextend.i32 v432
     brz v433, ebb52
+    jump ebb154
+
+ebb154:
     v434 = global_value.i64 gv30
     trap user0
 
@@ -941,6 +974,9 @@ ebb52:
     v447 = load.i8 v446
     v448 = uextend.i32 v447
     brz v448, ebb53
+    jump ebb153
+
+ebb153:
     v449 = global_value.i64 gv31
     trap user0
 
@@ -960,6 +996,9 @@ ebb53:
     v462 = load.i8 v461
     v463 = uextend.i32 v462
     brz v463, ebb54
+    jump ebb152
+
+ebb152:
     v464 = global_value.i64 gv32
     trap user0
 
@@ -976,6 +1015,9 @@ ebb54:
     v474 = load.i8 v473
     v475 = uextend.i32 v474
     brz v475, ebb55
+    jump ebb151
+
+ebb151:
     v476 = global_value.i64 gv33
     trap user0
 
@@ -1002,6 +1044,9 @@ ebb56:
     v493 = load.i8 v492
     v494 = uextend.i32 v493
     brz v494, ebb57
+    jump ebb150
+
+ebb150:
     v495 = global_value.i64 gv34
     trap user0
 
@@ -1017,6 +1062,9 @@ ebb57:
     v504 = load.i8 v503
     v505 = uextend.i32 v504
     brz v505, ebb58
+    jump ebb149
+
+ebb149:
     v506 = global_value.i64 gv35
     trap user0
 
@@ -1032,6 +1080,9 @@ ebb58:
     v517 = load.i8 v516
     v518 = uextend.i32 v517
     brz v518, ebb59
+    jump ebb148
+
+ebb148:
     v519 = global_value.i64 gv36
     trap user0
 
@@ -1049,6 +1100,9 @@ ebb59:
     v530 = load.i8 v529
     v531 = uextend.i32 v530
     brz v531, ebb60
+    jump ebb147
+
+ebb147:
     v532 = global_value.i64 gv37
     trap user0
 
@@ -1065,6 +1119,9 @@ ebb60:
     v542 = load.i8 v541
     v543 = uextend.i32 v542
     brz v543, ebb61
+    jump ebb146
+
+ebb146:
     v544 = global_value.i64 gv38
     trap user0
 
@@ -1118,6 +1175,9 @@ ebb62(v552: i32, v1009: i64, v1013: i64, v1016: i64, v1019: i64, v1022: i16, v10
     v556 = bint.i8 v555
     v557 = uextend.i32 v556
     brz v557, ebb63
+    jump ebb145
+
+ebb145:
     v558 = global_value.i64 gv39
     trap user0
 
@@ -1131,6 +1191,9 @@ ebb63:
     v566 = bint.i8 v565
     v567 = uextend.i32 v566
     brz v567, ebb64
+    jump ebb144
+
+ebb144:
     v568 = global_value.i64 gv40
     trap user0
 
@@ -1175,6 +1238,9 @@ ebb68(v584: i32):
     v593 = load.i8 v592
     v594 = uextend.i32 v593
     brz v594, ebb69
+    jump ebb143
+
+ebb143:
     v595 = global_value.i64 gv43
     trap user0
 
@@ -1185,6 +1251,9 @@ ebb69:
     v600 = bint.i8 v599
     v601 = uextend.i32 v600
     brnz v601, ebb70
+    jump ebb142
+
+ebb142:
     v602 = global_value.i64 gv44
     trap user0
 
@@ -1205,6 +1274,9 @@ ebb70:
     v618 = load.i8 v617
     v619 = uextend.i32 v618
     brz v619, ebb71
+    jump ebb141
+
+ebb141:
     v620 = global_value.i64 gv45
     trap user0
 
@@ -1225,6 +1297,9 @@ ebb71:
     v632 = load.i8 v631
     v633 = uextend.i32 v632
     brz v633, ebb72
+    jump ebb140
+
+ebb140:
     v634 = global_value.i64 gv46
     trap user0
 
@@ -1240,6 +1315,9 @@ ebb72:
     v644 = load.i8 v643
     v645 = uextend.i32 v644
     brz v645, ebb73
+    jump ebb139
+
+ebb139:
     v646 = global_value.i64 gv47
     trap user0
 
@@ -1266,6 +1344,9 @@ ebb74:
     v662 = load.i8 v661
     v663 = uextend.i32 v662
     brz v663, ebb75
+    jump ebb138
+
+ebb138:
     v664 = global_value.i64 gv48
     trap user0
 
@@ -1294,6 +1375,9 @@ ebb76:
     v686 = load.i8 v685
     v687 = uextend.i32 v686
     brz v687, ebb77
+    jump ebb137
+
+ebb137:
     v688 = global_value.i64 gv49
     trap user0
 
@@ -1465,6 +1549,9 @@ ebb96:
     v790 = load.i8 v789
     v791 = uextend.i32 v790
     brz v791, ebb97
+    jump ebb136
+
+ebb136:
     v792 = global_value.i64 gv58
     trap user0
 
@@ -1476,6 +1563,9 @@ ebb97:
     v797 = bint.i8 v796
     v798 = uextend.i32 v797
     brz v798, ebb98
+    jump ebb135
+
+ebb135:
     v799 = global_value.i64 gv59
     trap user0
 
@@ -1515,6 +1605,9 @@ ebb99(v804: i64, v1035: i64, v1037: i64, v1039: i64, v1044: i64, v1052: i16, v10
     v813 = load.i8 v812
     v814 = uextend.i32 v813
     brz v814, ebb100
+    jump ebb134
+
+ebb134:
     v815 = global_value.i64 gv60
     trap user0
 
@@ -1534,6 +1627,9 @@ ebb100:
     v826 = load.i8 v825
     v827 = uextend.i32 v826
     brz v827, ebb101
+    jump ebb133
+
+ebb133:
     v828 = global_value.i64 gv61
     trap user0
 
@@ -1555,6 +1651,9 @@ ebb101:
     v839 = load.i8 v838
     v840 = uextend.i32 v839
     brz v840, ebb102
+    jump ebb132
+
+ebb132:
     v841 = global_value.i64 gv62
     trap user0
 
@@ -1574,6 +1673,9 @@ ebb102:
     v852 = load.i8 v851
     v853 = uextend.i32 v852
     brz v853, ebb103
+    jump ebb131
+
+ebb131:
     v854 = global_value.i64 gv63
     trap user0
 
@@ -1591,6 +1693,9 @@ ebb103:
     v866 = load.i8 v865
     v867 = uextend.i32 v866
     brz v867, ebb104
+    jump ebb130
+
+ebb130:
     v868 = global_value.i64 gv64
     trap user0
 
@@ -1607,6 +1712,9 @@ ebb104:
     v878 = load.i8 v877
     v879 = uextend.i32 v878
     brz v879, ebb105
+    jump ebb129
+
+ebb129:
     v880 = global_value.i64 gv65
     trap user0
 
@@ -1654,6 +1762,9 @@ ebb109(v896: i64):
     v905 = load.i8 v904
     v906 = uextend.i32 v905
     brz v906, ebb110
+    jump ebb128
+
+ebb128:
     v907 = global_value.i64 gv68
     trap user0
 
@@ -1664,6 +1775,9 @@ ebb110:
     v912 = bint.i8 v911
     v913 = uextend.i32 v912
     brnz v913, ebb111
+    jump ebb127
+
+ebb127:
     v914 = global_value.i64 gv69
     trap user0
 
@@ -1684,6 +1798,9 @@ ebb111:
     v930 = load.i8 v929
     v931 = uextend.i32 v930
     brz v931, ebb112
+    jump ebb126
+
+ebb126:
     v932 = global_value.i64 gv70
     trap user0
 
@@ -1709,6 +1826,9 @@ ebb113:
     v948 = load.i8 v947
     v949 = uextend.i32 v948
     brz v949, ebb114
+    jump ebb125
+
+ebb125:
     v950 = global_value.i64 gv71
     trap user0
 
@@ -1737,6 +1857,9 @@ ebb115:
     v972 = load.i8 v971
     v973 = uextend.i32 v972
     brz v973, ebb116
+    jump ebb123
+
+ebb123:
     v974 = global_value.i64 gv72
     trap user0
 
@@ -1752,6 +1875,9 @@ ebb116:
     v984 = load.i8 v983
     v985 = uextend.i32 v984
     brz v985, ebb117
+    jump ebb122
+
+ebb122:
     v986 = global_value.i64 gv73
     trap user0
 
@@ -1775,6 +1901,9 @@ ebb119:
     v1001 = load.i8 v1000
     v1002 = uextend.i32 v1001
     brz v1002, ebb120
+    jump ebb121
+
+ebb121:
     v1003 = global_value.i64 gv74
     trap user0
 


### PR DESCRIPTION
This is a WIP change published as a PR for discussion. The main ideas are:
 - it adds a `Bindable` trait and associated conversions to unify all of the `bind_any`, `bind_ref`, etc. to a single `bind` (though I have retained a helper `bind_vector` due to it having a second parameter
 - when a immediate value is passed to `bind` the `EncodingBuilder` should add the appropriate predicate to ensure that the encoding is only applied if the immediate value in the code matches the bound immediate value (this is not finished: see notes on code).